### PR TITLE
EPT Update

### DIFF
--- a/include/vmcs/ept_entry_intel_x64.h
+++ b/include/vmcs/ept_entry_intel_x64.h
@@ -97,13 +97,6 @@ public:
     using integer_pointer = uintptr_t;
     using memory_type_type = uint64_t;
 
-    /// Invalid Constructor
-    ///
-    /// @expects none
-    /// @ensures none
-    ///
-    ept_entry_intel_x64() noexcept;
-
     /// Default Constructor
     ///
     /// @expects pte != nullptr
@@ -111,14 +104,14 @@ public:
     ///
     /// @param pte the pte that this page table entry encapsulates.
     ///
-    ept_entry_intel_x64(const gsl::not_null<pointer> &pte) noexcept;
+    ept_entry_intel_x64(gsl::not_null<pointer> pte) noexcept;
 
     /// Destructor
     ///
     /// @expects none
     /// @ensures none
     ///
-    virtual ~ept_entry_intel_x64() = default;
+    ~ept_entry_intel_x64() = default;
 
     /// Read Access
     ///

--- a/include/vmcs/ept_intel_x64.h
+++ b/include/vmcs/ept_intel_x64.h
@@ -28,7 +28,7 @@
 #include <memory>
 #include <vmcs/ept_entry_intel_x64.h>
 
-class ept_intel_x64 : public ept_entry_intel_x64
+class ept_intel_x64
 {
 public:
 
@@ -55,19 +55,9 @@ public:
     /// @expects none
     /// @ensures none
     ///
-    ~ept_intel_x64() override = default;
+    ~ept_intel_x64() = default;
 
-    /// Global Size
-    ///
-    /// @expects none
-    /// @ensures none
-    ///
-    /// @return returns the number of entries in the entire ept
-    ///     tree. Note that this function is expensive.
-    ///
-    size_type global_size() const noexcept;
-
-    /// Add Page (1 Gigabyte Granularity)
+    /// Add Page (1g Granularity)
     ///
     /// Adds a page to the extended page table structure. Note that this is the
     /// public function, and should only be used to add pages to the
@@ -82,10 +72,10 @@ public:
     /// @return the resulting epte. Note that this epte is blank, and its
     ///     properties should be set by the caller
     ///
-    gsl::not_null<ept_entry_intel_x64 *> add_page_1g(integer_pointer addr)
+    ept_entry_intel_x64 add_page_1g(integer_pointer addr)
     { return add_page(addr, intel_x64::ept::pml4::from, intel_x64::ept::pdpt::from); }
 
-    /// Add Page (2 Megabyte Granularity)
+    /// Add Page (2m Granularity)
     ///
     /// Adds a page to the extended page table structure. Note that this is the
     /// public function, and should only be used to add pages to the
@@ -100,10 +90,10 @@ public:
     /// @return the resulting epte. Note that this epte is blank, and its
     ///     properties should be set by the caller
     ///
-    gsl::not_null<ept_entry_intel_x64 *> add_page_2m(integer_pointer addr)
+    ept_entry_intel_x64 add_page_2m(integer_pointer addr)
     { return add_page(addr, intel_x64::ept::pml4::from, intel_x64::ept::pd::from); }
 
-    /// Add Page (4 Kilobyte Granularity)
+    /// Add Page (4k Granularity)
     ///
     /// Adds a page to the extended page table structure. Note that this is the
     /// public function, and should only be used to add pages to the
@@ -118,7 +108,7 @@ public:
     /// @return the resulting epte. Note that this epte is blank, and its
     ///     properties should be set by the caller
     ///
-    gsl::not_null<ept_entry_intel_x64 *> add_page_4k(integer_pointer addr)
+    ept_entry_intel_x64 add_page_4k(integer_pointer addr)
     { return add_page(addr, intel_x64::ept::pml4::from, intel_x64::ept::pt::from); }
 
     /// Remove Page
@@ -146,32 +136,25 @@ public:
     ///
     /// @param addr the virtual address of the page to lookup
     ///
-    gsl::not_null<ept_entry_intel_x64 *> find_epte(integer_pointer addr)
-    { return find_epte(addr, intel_x64::ept::pml4::from); }
+    ept_entry_intel_x64 phys_to_epte(integer_pointer addr)
+    { return phys_to_epte(addr, intel_x64::ept::pml4::from); }
 
 private:
 
-    template<class T> std::unique_ptr<T> add_epte(pointer p);
-    template<class T> std::unique_ptr<T> remove_epte();
+    ept_entry_intel_x64 add_page(integer_pointer addr, integer_pointer bits, integer_pointer end);
+    void remove_page(integer_pointer addr, integer_pointer bits);
+    ept_entry_intel_x64 phys_to_epte(integer_pointer addr, integer_pointer bits);
 
-    gsl::not_null<ept_entry_intel_x64 *> add_page(
-        integer_pointer addr, integer_pointer bits, integer_pointer end_bits);
-    void remove_page(
-        integer_pointer addr, integer_pointer bits);
-    gsl::not_null<ept_entry_intel_x64 *> find_epte(
-        integer_pointer addr, integer_pointer bits);
-
-    auto empty() const noexcept
-    { return m_size == 0; }
+    bool empty() const noexcept;
+    size_type global_size() const noexcept;
+    size_type global_capacity() const noexcept;
 
 private:
 
-    gsl::span<integer_pointer> m_ept;
-    std::unique_ptr<integer_pointer[]> m_ept_owner;
+    friend class eapis_ut;
 
-    size_type m_size;
-    integer_pointer m_bitbucket;
-    std::vector<std::unique_ptr<ept_entry_intel_x64>> m_eptes;
+    std::unique_ptr<integer_pointer[]> m_ept;
+    std::vector<std::unique_ptr<ept_intel_x64>> m_epts;
 
 public:
 

--- a/include/vmcs/vmcs_intel_x64_eapis.h
+++ b/include/vmcs/vmcs_intel_x64_eapis.h
@@ -289,7 +289,7 @@ public:
     ///
     void unmap(integer_pointer gpa) noexcept;
 
-    /// Setup EPT Identify Map (1 Gigabyte Granularity)
+    /// Setup EPT Identify Map (1g Granularity)
     ///
     /// Sets up an identify map in the extended page tables using 1 gigabyte
     /// of memory granularity. Lower granularity takes up far less memory,
@@ -314,7 +314,7 @@ public:
     ///
     void setup_ept_identity_map_1g(integer_pointer saddr, integer_pointer eaddr);
 
-    /// Setup EPT Identify Map (2 Megabyte Granularity)
+    /// Setup EPT Identify Map (2m Granularity)
     ///
     /// Sets up an identify map in the extended page tables using 2 megabytes
     /// of memory granularity. Lower granularity takes up far less memory,
@@ -339,7 +339,7 @@ public:
     ///
     void setup_ept_identity_map_2m(integer_pointer saddr, integer_pointer eaddr);
 
-    /// Setup EPT Identify Map (4 Kilobyte Granularity)
+    /// Setup EPT Identify Map (4k Granularity)
     ///
     /// Sets up an identify map in the extended page tables using 4 kilobyte
     /// of memory granularity. Lower granularity takes up far less memory,
@@ -364,6 +364,45 @@ public:
     ///
     void setup_ept_identity_map_4k(integer_pointer saddr, integer_pointer eaddr);
 
+    /// Unmap EPT Identify Map (1g Granularity)
+    ///
+    /// Unmaps an identity map previously mapped using the
+    /// setup_ept_identity_map_1g function.
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @param saddr the starting address for the identify map
+    /// @param eaddr the ending address for the identify map
+    ///
+    void unmap_ept_identity_map_1g(integer_pointer saddr, integer_pointer eaddr);
+
+    /// Unmap EPT Identify Map (2m Granularity)
+    ///
+    /// Unmaps an identity map previously mapped using the
+    /// setup_ept_identity_map_2m function.
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @param saddr the starting address for the identify map
+    /// @param eaddr the ending address for the identify map
+    ///
+    void unmap_ept_identity_map_2m(integer_pointer saddr, integer_pointer eaddr);
+
+    /// Unmap EPT Identify Map (4k Granularity)
+    ///
+    /// Unmaps an identity map previously mapped using the
+    /// setup_ept_identity_map_4k function.
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @param saddr the starting address for the identify map
+    /// @param eaddr the ending address for the identify map
+    ///
+    void unmap_ept_identity_map_4k(integer_pointer saddr, integer_pointer eaddr);
+
     /// Guest Physical Address To Extended Page Table Entry
     ///
     /// Locates the extended page table entry given a guest physical
@@ -379,7 +418,7 @@ public:
     /// @param gpa the guest physical address to lookup
     /// @return the resulting EPTE
     ///
-    gsl::not_null<ept_entry_intel_x64 *> gpa_to_epte(integer_pointer gpa);
+    ept_entry_intel_x64 gpa_to_epte(integer_pointer gpa);
 
 protected:
 
@@ -387,8 +426,10 @@ protected:
                       gsl::not_null<vmcs_intel_x64_state *> guest_state) override;
 
     virtual std::mutex &eptp_mutex() const;
+    virtual gsl::not_null<integer_pointer *> eptp_entry() const;
     virtual gsl::not_null<ept_intel_x64 *> eptp() const;
 
+    ept_entry_intel_x64 add_page(integer_pointer gpa, size_type size);
     void map(integer_pointer gpa, integer_pointer phys_addr, attr_type attr, size_type size);
 
 protected:

--- a/src/vmcs/src/ept_entry_intel_x64.cpp
+++ b/src/vmcs/src/ept_entry_intel_x64.cpp
@@ -25,15 +25,9 @@
 #include <intrinsics/x64.h>
 using namespace x64;
 
-static ept_entry_intel_x64::integer_pointer g_invalid_epte = 0;
-
-ept_entry_intel_x64::ept_entry_intel_x64() noexcept :
-    m_epte(&g_invalid_epte)
-{ *m_epte = 0; }
-
-ept_entry_intel_x64::ept_entry_intel_x64(const gsl::not_null<pointer> &pte) noexcept :
+ept_entry_intel_x64::ept_entry_intel_x64(gsl::not_null<pointer> pte) noexcept :
     m_epte(pte.get())
-{ *m_epte = 0; }
+{ }
 
 bool
 ept_entry_intel_x64::read_access() const noexcept

--- a/src/vmcs/test/test.cpp
+++ b/src/vmcs/test/test.cpp
@@ -63,7 +63,6 @@ eapis_ut::list()
     this->test_setup_ept_identity_map_4k_invalid();
     this->test_setup_ept_identity_map_4k_valid();
 
-    this->test_ept_entry_intel_x64_invalid();
     this->test_ept_entry_intel_x64_read_access();
     this->test_ept_entry_intel_x64_write_access();
     this->test_ept_entry_intel_x64_execute_access();
@@ -79,14 +78,16 @@ eapis_ut::list()
     this->test_ept_entry_intel_x64_pass_through_access();
     this->test_ept_entry_intel_x64_clear();
 
-    this->test_ept_intel_x64_no_entry();
-    this->test_ept_intel_x64_with_entry();
+    this->test_ept_intel_x64_add_remove_page_success_without_setting();
     this->test_ept_intel_x64_add_remove_page_1g_success();
     this->test_ept_intel_x64_add_remove_page_2m_success();
     this->test_ept_intel_x64_add_remove_page_4k_success();
-    this->test_ept_intel_x64_add_page_twice_failure();
-    this->test_ept_intel_x64_remove_page_twice_failure();
-    this->test_ept_intel_x64_remove_page_unknown_failure();
+    this->test_ept_intel_x64_add_remove_page_swap_success();
+    this->test_ept_intel_x64_add_page_twice_success();
+    this->test_ept_intel_x64_remove_page_twice_success();
+    this->test_ept_intel_x64_remove_page_unknown_success();
+    this->test_ept_intel_x64_phys_to_epte_invalid();
+    this->test_ept_intel_x64_phys_to_epte_success();
 
     return true;
 }

--- a/src/vmcs/test/test.h
+++ b/src/vmcs/test/test.h
@@ -62,7 +62,6 @@ private:
     void test_setup_ept_identity_map_4k_invalid();
     void test_setup_ept_identity_map_4k_valid();
 
-    void test_ept_entry_intel_x64_invalid();
     void test_ept_entry_intel_x64_read_access();
     void test_ept_entry_intel_x64_write_access();
     void test_ept_entry_intel_x64_execute_access();
@@ -78,16 +77,16 @@ private:
     void test_ept_entry_intel_x64_pass_through_access();
     void test_ept_entry_intel_x64_clear();
 
-    void test_ept_intel_x64_no_entry();
-    void test_ept_intel_x64_with_entry();
+    void test_ept_intel_x64_add_remove_page_success_without_setting();
     void test_ept_intel_x64_add_remove_page_1g_success();
     void test_ept_intel_x64_add_remove_page_2m_success();
     void test_ept_intel_x64_add_remove_page_4k_success();
-    void test_ept_intel_x64_add_page_twice_failure();
-    void test_ept_intel_x64_remove_page_twice_failure();
-    void test_ept_intel_x64_remove_page_unknown_failure();
-
-
+    void test_ept_intel_x64_add_remove_page_swap_success();
+    void test_ept_intel_x64_add_page_twice_success();
+    void test_ept_intel_x64_remove_page_twice_success();
+    void test_ept_intel_x64_remove_page_unknown_success();
+    void test_ept_intel_x64_phys_to_epte_invalid();
+    void test_ept_intel_x64_phys_to_epte_success();
 };
 
 #endif

--- a/src/vmcs/test/test_ept_entry_intel_x64.cpp
+++ b/src/vmcs/test/test_ept_entry_intel_x64.cpp
@@ -27,12 +27,6 @@
 using epte_type = ept_entry_intel_x64::integer_pointer;
 
 void
-eapis_ut::test_ept_entry_intel_x64_invalid()
-{
-    std::make_unique<ept_entry_intel_x64>();
-}
-
-void
 eapis_ut::test_ept_entry_intel_x64_read_access()
 {
     epte_type entry = 0;

--- a/src/vmcs/test/test_vmcs_intel_x64_eapis.cpp
+++ b/src/vmcs/test/test_vmcs_intel_x64_eapis.cpp
@@ -274,10 +274,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::rw_uc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 0);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 0);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -285,10 +285,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::rw_wc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 1);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 1);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -296,10 +296,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::rw_wt);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 4);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 4);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -307,10 +307,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::rw_wp);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 5);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 5);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -318,10 +318,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::rw_wb);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 6);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 6);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -330,10 +330,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::re_uc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 0);
+        this->expect_true(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 0);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -341,10 +341,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::re_wc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 1);
+        this->expect_true(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 1);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -352,10 +352,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::re_wt);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 4);
+        this->expect_true(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 4);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -363,10 +363,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::re_wp);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 5);
+        this->expect_true(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 5);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -374,10 +374,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::re_wb);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 6);
+        this->expect_true(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 6);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -386,10 +386,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::eo_uc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 0);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 0);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -397,10 +397,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::eo_wc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 1);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 1);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -408,10 +408,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::eo_wt);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 4);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 4);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -419,10 +419,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::eo_wp);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 5);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 5);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -430,10 +430,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::eo_wb);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 6);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 6);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -442,10 +442,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::pt_uc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 0);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 0);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -453,10 +453,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::pt_wc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 1);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 1);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -464,10 +464,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::pt_wt);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 4);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 4);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -475,10 +475,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::pt_wp);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 5);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 5);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -486,10 +486,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::pt_wb);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 6);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 6);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -498,10 +498,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::tp_uc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 0);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 0);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -509,10 +509,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::tp_wc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 1);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 1);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -520,10 +520,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::tp_wt);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 4);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 4);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -531,10 +531,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::tp_wp);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 5);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 5);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -542,10 +542,10 @@ eapis_ut::test_map_1g()
     {
         vmcs->map_1g(0x1000UL, 0x1000UL, ept::memory_attr::tp_wb);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 6);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 6);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -562,10 +562,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::rw_uc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 0);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 0);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -573,10 +573,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::rw_wc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 1);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 1);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -584,10 +584,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::rw_wt);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 4);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 4);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -595,10 +595,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::rw_wp);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 5);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 5);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -606,10 +606,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::rw_wb);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 6);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 6);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -618,10 +618,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::re_uc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 0);
+        this->expect_true(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 0);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -629,10 +629,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::re_wc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 1);
+        this->expect_true(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 1);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -640,10 +640,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::re_wt);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 4);
+        this->expect_true(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 4);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -651,10 +651,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::re_wp);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 5);
+        this->expect_true(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 5);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -662,10 +662,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::re_wb);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 6);
+        this->expect_true(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 6);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -674,10 +674,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::eo_uc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 0);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 0);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -685,10 +685,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::eo_wc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 1);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 1);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -696,10 +696,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::eo_wt);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 4);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 4);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -707,10 +707,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::eo_wp);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 5);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 5);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -718,10 +718,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::eo_wb);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 6);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 6);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -730,10 +730,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::pt_uc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 0);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 0);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -741,10 +741,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::pt_wc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 1);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 1);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -752,10 +752,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::pt_wt);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 4);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 4);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -763,10 +763,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::pt_wp);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 5);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 5);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -774,10 +774,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::pt_wb);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 6);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 6);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -786,10 +786,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::tp_uc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 0);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 0);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -797,10 +797,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::tp_wc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 1);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 1);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -808,10 +808,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::tp_wt);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 4);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 4);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -819,10 +819,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::tp_wp);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 5);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 5);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -830,10 +830,10 @@ eapis_ut::test_map_2m()
     {
         vmcs->map_2m(0x1000UL, 0x1000UL, ept::memory_attr::tp_wb);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 6);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 6);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -850,10 +850,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::rw_uc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 0);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 0);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -861,10 +861,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::rw_wc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 1);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 1);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -872,10 +872,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::rw_wt);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 4);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 4);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -883,10 +883,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::rw_wp);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 5);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 5);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -894,10 +894,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::rw_wb);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 6);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 6);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -906,10 +906,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::re_uc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 0);
+        this->expect_true(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 0);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -917,10 +917,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::re_wc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 1);
+        this->expect_true(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 1);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -928,10 +928,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::re_wt);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 4);
+        this->expect_true(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 4);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -939,10 +939,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::re_wp);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 5);
+        this->expect_true(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 5);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -950,10 +950,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::re_wb);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 6);
+        this->expect_true(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 6);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -962,10 +962,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::eo_uc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 0);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 0);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -973,10 +973,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::eo_wc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 1);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 1);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -984,10 +984,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::eo_wt);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 4);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 4);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -995,10 +995,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::eo_wp);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 5);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 5);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -1006,10 +1006,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::eo_wb);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 6);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 6);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -1018,10 +1018,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::pt_uc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 0);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 0);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -1029,10 +1029,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::pt_wc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 1);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 1);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -1040,10 +1040,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::pt_wt);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 4);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 4);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -1051,10 +1051,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::pt_wp);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 5);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 5);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -1062,10 +1062,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::pt_wb);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_true(entry->read_access());
-        this->expect_true(entry->write_access());
-        this->expect_true(entry->execute_access());
-        this->expect_true(entry->memory_type() == 6);
+        this->expect_true(entry.read_access());
+        this->expect_true(entry.write_access());
+        this->expect_true(entry.execute_access());
+        this->expect_true(entry.memory_type() == 6);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -1074,10 +1074,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::tp_uc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 0);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 0);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -1085,10 +1085,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::tp_wc);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 1);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 1);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -1096,10 +1096,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::tp_wt);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 4);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 4);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -1107,10 +1107,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::tp_wp);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 5);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 5);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -1118,10 +1118,10 @@ eapis_ut::test_map_4k()
     {
         vmcs->map_4k(0x1000UL, 0x1000UL, ept::memory_attr::tp_wb);
         auto &&entry = vmcs->gpa_to_epte(0x1000UL);
-        this->expect_false(entry->read_access());
-        this->expect_false(entry->write_access());
-        this->expect_false(entry->execute_access());
-        this->expect_true(entry->memory_type() == 6);
+        this->expect_false(entry.read_access());
+        this->expect_false(entry.write_access());
+        this->expect_false(entry.execute_access());
+        this->expect_true(entry.memory_type() == 6);
         vmcs->unmap(0x1000UL);
         this->expect_exception([&] { vmcs->gpa_to_epte(0x1000UL); }, ""_ut_ree);
     }
@@ -1147,6 +1147,8 @@ eapis_ut::test_setup_ept_identity_map_1g_invalid()
 
     this->expect_exception([&] { vmcs->setup_ept_identity_map_1g(0x1, 0x40000000); }, ""_ut_ffe);
     this->expect_exception([&] { vmcs->setup_ept_identity_map_1g(0x0, 0x40000001); }, ""_ut_ffe);
+    this->expect_exception([&] { vmcs->unmap_ept_identity_map_1g(0x1, 0x40000000); }, ""_ut_ffe);
+    this->expect_exception([&] { vmcs->unmap_ept_identity_map_1g(0x0, 0x40000001); }, ""_ut_ffe);
 }
 
 void
@@ -1157,9 +1159,7 @@ eapis_ut::test_setup_ept_identity_map_1g_valid()
     auto &&vmcs = setup_vmcs();
 
     this->expect_no_exception([&] { vmcs->setup_ept_identity_map_1g(0x0, 0x40000000); });
-
-    for (auto virt = 0x0UL; virt < 0x40000000UL; virt += ept::pdpt::size_bytes)
-        vmcs->unmap(virt);
+    this->expect_no_exception([&] { vmcs->unmap_ept_identity_map_1g(0x0, 0x40000000); });
 }
 
 void
@@ -1169,8 +1169,10 @@ eapis_ut::test_setup_ept_identity_map_2m_invalid()
     setup_mm(mocks);
     auto &&vmcs = setup_vmcs();
 
-    this->expect_exception([&] { vmcs->setup_ept_identity_map_2m(0x1, 0x40000000); }, ""_ut_ffe);
-    this->expect_exception([&] { vmcs->setup_ept_identity_map_2m(0x0, 0x40000001); }, ""_ut_ffe);
+    this->expect_exception([&] { vmcs->setup_ept_identity_map_2m(0x1, 0x200000); }, ""_ut_ffe);
+    this->expect_exception([&] { vmcs->setup_ept_identity_map_2m(0x0, 0x200001); }, ""_ut_ffe);
+    this->expect_exception([&] { vmcs->unmap_ept_identity_map_2m(0x1, 0x200000); }, ""_ut_ffe);
+    this->expect_exception([&] { vmcs->unmap_ept_identity_map_2m(0x0, 0x200001); }, ""_ut_ffe);
 }
 
 void
@@ -1180,10 +1182,8 @@ eapis_ut::test_setup_ept_identity_map_2m_valid()
     setup_mm(mocks);
     auto &&vmcs = setup_vmcs();
 
-    this->expect_no_exception([&] { vmcs->setup_ept_identity_map_2m(0x0, 0x40000000); });
-
-    for (auto virt = 0x0UL; virt < 0x40000000UL; virt += ept::pd::size_bytes)
-        vmcs->unmap(virt);
+    this->expect_no_exception([&] { vmcs->setup_ept_identity_map_2m(0x0, 0x200000); });
+    this->expect_no_exception([&] { vmcs->unmap_ept_identity_map_2m(0x0, 0x200000); });
 }
 
 void
@@ -1193,8 +1193,10 @@ eapis_ut::test_setup_ept_identity_map_4k_invalid()
     setup_mm(mocks);
     auto &&vmcs = setup_vmcs();
 
-    this->expect_exception([&] { vmcs->setup_ept_identity_map_4k(0x1, 0x40000000); }, ""_ut_ffe);
-    this->expect_exception([&] { vmcs->setup_ept_identity_map_4k(0x0, 0x40000001); }, ""_ut_ffe);
+    this->expect_exception([&] { vmcs->setup_ept_identity_map_4k(0x1, 0x1000); }, ""_ut_ffe);
+    this->expect_exception([&] { vmcs->setup_ept_identity_map_4k(0x0, 0x1001); }, ""_ut_ffe);
+    this->expect_exception([&] { vmcs->unmap_ept_identity_map_4k(0x1, 0x1000); }, ""_ut_ffe);
+    this->expect_exception([&] { vmcs->unmap_ept_identity_map_4k(0x0, 0x1001); }, ""_ut_ffe);
 }
 
 void
@@ -1204,8 +1206,6 @@ eapis_ut::test_setup_ept_identity_map_4k_valid()
     setup_mm(mocks);
     auto &&vmcs = setup_vmcs();
 
-    this->expect_no_exception([&] { vmcs->setup_ept_identity_map_4k(0x0, 0x40000000); });
-
-    for (auto virt = 0x0UL; virt < 0x40000000UL; virt += ept::pt::size_bytes)
-        vmcs->unmap(virt);
+    this->expect_no_exception([&] { vmcs->setup_ept_identity_map_4k(0x0, 0x1000); });
+    this->expect_no_exception([&] { vmcs->unmap_ept_identity_map_4k(0x0, 0x1000); });
 }


### PR DESCRIPTION
Updates the EPT implementation to match the new CR3 logic.
Specifically, this reduces the memory footprint of the
the page tables being used, and cleans up some bugs.

Signed-off-by: “Rian <“rianquinn@gmail.com”>