### PR TITLE
Remove duplicate member in root_ept_intel_x64

### DIFF
--- a/include/vmcs/root_ept_intel_x64.h
+++ b/include/vmcs/root_ept_intel_x64.h
@@ -250,20 +250,6 @@ public:
     ///
     memory_descriptor_list ept_to_mdl() const;
 
-    /// Extended Page Table to Memory Descriptor List
-    ///
-    /// This function converts the internal page table tree structure into a
-    /// linear, memory descriptor list. Page table entry information is not
-    /// provide, only the page tables.
-    /// pages.
-    ///
-    /// @expects
-    /// @ensures
-    ///
-    /// @return memory descriptor list
-    ///
-    memory_descriptor_list ept_to_mdl() const;
-
 private:
 
     ept_entry_intel_x64 add_page(integer_pointer gpa, size_type size);


### PR DESCRIPTION
This patch removes the duplicate ept_to_mdl member
function in root_ept_intel_x64 and allows for the eapis
to build successfully.