### PR TITLE
Bear Issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,11 +100,11 @@ matrix:
       - TEST="Clang Tidy"
     install:
       - git clone https://github.com/rizsotto/bear.git
-      - pushd bear; cmake .; make; sudo make install; popd
+      - pushd bear; git reset --hard 37b96a184f32b859c8f25ea2dc0d3f07242a9a98; cmake .; make; sudo make install; popd
     script:
       - ./configure --compiler clang-3.8
       - STATIC_ANALYSIS_ENABLED=true bear make
-      - HYPERKERNEL_EXTENSION=true make tidy
+      - EXTENDED_APIS_EXTENSION=true make tidy
 
   #
   # Google Sanitizers


### PR DESCRIPTION
Bear committed a patch that broke everything, including Travis CI.
This hard codes Clang Tidy to a working version until it can be
addressed. Since v1.2 will have a new build system based on CMake,
this will not be needed in the future.

Signed-off-by: Rian Quinn <“rianquinn@gmail.com”>