### PR TITLE
Fixes for ept_intel_x64

### DIFF
--- a/include/vmcs/ept_intel_x64.h
+++ b/include/vmcs/ept_intel_x64.h
@@ -37,6 +37,7 @@ public:
     using pointer = uintptr_t *;
     using integer_pointer = uintptr_t;
     using size_type = std::size_t;
+    using index_type = uint64_t;
     using memory_descriptor_list = std::vector<memory_descriptor>;
 
     /// Constructor
@@ -60,7 +61,20 @@ public:
     ///
     ~ept_intel_x64() = default;
 
-    /// Add Page (1g Granularity)
+    ///
+    /// Get an EPT entry
+    ///
+    /// Retrieves the EPT entry at the given index.
+    ///
+    /// @expects none
+    /// @ensures none
+    //
+    /// @param index the index of the entry to retrieve.
+    /// @return an entry object constructed from the data at @param index.
+    ///
+    ept_entry_intel_x64 get_entry(index_type index);
+
+    /// Add Page (1G Granularity)
     ///
     /// Adds a page to the extended page table structure. Note that this is the
     /// public function, and should only be used to add pages to the
@@ -68,17 +82,27 @@ public:
     /// will parse through the different levels making sure the guest physical
     /// address provided is valid.
     ///
+    /// If the gpa maps to a table entry, an exception is thrown.
+    ///
+    /// If the gpa maps to a page entry with higher granularity than 1G,
+    /// an exception is thrown.
+    ///
+    /// If the gpa maps to a page entry with 1G granularity, it returns the
+    /// entry unmodified.
+    ///
+    /// Otherwise, it returns an entry with only bit 7 set
+    /// (so the entry maps a 1G page).
+    ///
     /// @expects none
     /// @ensures none
     ///
     /// @param gpa the guest physical address of the page to add
-    /// @return the resulting epte. Note that this epte is blank, and its
-    ///     properties should be set by the caller
+    /// @return the resulting epte.
     ///
     ept_entry_intel_x64 add_page_1g(integer_pointer gpa)
     { return add_page(gpa, intel_x64::ept::pml4::from, intel_x64::ept::pdpt::from); }
 
-    /// Add Page (2m Granularity)
+    /// Add Page (2M Granularity)
     ///
     /// Adds a page to the extended page table structure. Note that this is the
     /// public function, and should only be used to add pages to the
@@ -86,17 +110,27 @@ public:
     /// will parse through the different levels making sure the guest physical
     /// address provided is valid.
     ///
+    /// If the gpa maps to a table entry, an exception is thrown.
+    ///
+    /// If the gpa maps to a page entry with higher granularity than 2M,
+    /// an exception is thrown.
+    ///
+    /// If the gpa maps to a page entry with 2M granularity, it returns the
+    /// entry unmodified.
+    ///
+    /// Otherwise, it returns an entry with only bit 7 set
+    /// (so the entry maps a 2M page).
+    ///
     /// @expects none
     /// @ensures none
     ///
     /// @param gpa the guest physical address of the page to add
-    /// @return the resulting epte. Note that this epte is blank, and its
-    ///     properties should be set by the caller
+    /// @return the resulting epte.
     ///
     ept_entry_intel_x64 add_page_2m(integer_pointer gpa)
     { return add_page(gpa, intel_x64::ept::pml4::from, intel_x64::ept::pd::from); }
 
-    /// Add Page (4k Granularity)
+    /// Add Page (4K Granularity)
     ///
     /// Adds a page to the extended page table structure. Note that this is the
     /// public function, and should only be used to add pages to the
@@ -104,12 +138,20 @@ public:
     /// will parse through the different levels making sure the guest physical
     /// address provided is valid.
     ///
+    /// If the gpa maps to a page entry with higher granularity than 4K,
+    /// an exception is thrown.
+    ///
+    /// If the gpa maps to a page entry with 4K granularity, it returns the
+    /// entry unmodified.
+    ///
+    /// Otherwise, it returns an entry with only bit 7 set
+    /// (so the entry maps a 4K page).
+    ///
     /// @expects none
     /// @ensures none
     ///
     /// @param gpa the guest physical address of the page to add
-    /// @return the resulting epte. Note that this epte is blank, and its
-    ///     properties should be set by the caller
+    /// @return the resulting epte.
     ///
     ept_entry_intel_x64 add_page_4k(integer_pointer gpa)
     { return add_page(gpa, intel_x64::ept::pml4::from, intel_x64::ept::pt::from); }

--- a/src/vmcs/src/ept_intel_x64.cpp
+++ b/src/vmcs/src/ept_intel_x64.cpp
@@ -39,20 +39,34 @@ ept_intel_x64::ept_intel_x64(pointer epte)
 }
 
 ept_entry_intel_x64
+ept_intel_x64::get_entry(index_type index)
+{
+    if (index >= ept::num_entries)
+        throw std::invalid_argument("index must be less than ept::num_entries");
+
+    auto ept = gsl::make_span(m_ept, ept::num_entries);
+    return ept_entry_intel_x64(&ept.at(index));
+}
+
+ept_entry_intel_x64
 ept_intel_x64::add_page(integer_pointer gpa, integer_pointer bits, integer_pointer end)
 {
-    auto &&index = ept::index(gpa, bits);
+    auto index = ept::index(gpa, bits);
+    auto entry = get_entry(index);
 
     if (bits > end)
     {
+        if (entry.entry_type())
+            throw std::logic_error("unmap gpa before adding new page");
+
         if (m_epts.empty())
             m_epts = std::vector<std::unique_ptr<ept_intel_x64>>(ept::num_entries);
 
-        auto &&iter = bfn::find(m_epts, index);
-        if (!(*iter))
+        auto iter = bfn::find(m_epts, index);
+        if (nullptr == *iter)
         {
-            auto &&view = gsl::make_span(m_ept, ept::num_entries);
-            (*iter) = std::make_unique<ept_intel_x64>(&view.at(index));
+            auto view = gsl::make_span(m_ept, ept::num_entries);
+            *iter = std::make_unique<ept_intel_x64>(&view.at(index));
         }
 
         return (*iter)->add_page(gpa, bits - ept::pt::size, end);
@@ -60,40 +74,43 @@ ept_intel_x64::add_page(integer_pointer gpa, integer_pointer bits, integer_point
 
     if (!m_epts.empty())
     {
-        m_epts.clear();
-        m_epts.shrink_to_fit();
+        auto iter = bfn::find(m_epts, index);
+        if (nullptr != *iter)
+            throw std::logic_error("unmap gpa before adding new page");
     }
 
-    auto &&view = gsl::make_span(m_ept, ept::num_entries);
-    return ept_entry_intel_x64(&view.at(index));
+    if (entry.entry_type())
+        return entry;
+
+    entry.clear();
+    entry.set_entry_type(true);
+    return entry;
 }
 
 void
 ept_intel_x64::remove_page(integer_pointer gpa, integer_pointer bits)
 {
-    auto &&index = ept::index(gpa, bits);
+    auto index = ept::index(gpa, bits);
+    auto entry = get_entry(index);
+
+    if (entry.entry_type())
+    {
+        entry.clear();
+        return;
+    }
 
     if (!m_epts.empty())
     {
-        auto &&iter = bfn::find(m_epts, index);
+        auto iter = bfn::find(m_epts, index);
         if (auto pt = (*iter).get())
         {
             pt->remove_page(gpa, bits - ept::pt::size);
             if (pt->empty())
             {
                 (*iter) = nullptr;
-
-                auto &&view = gsl::make_span(m_ept, ept::num_entries);
-                view.at(index) = 0;
+                entry.clear();
             }
         }
-    }
-    else
-    {
-        auto &&view = gsl::make_span(m_ept, ept::num_entries);
-        view.at(index) = 0;
-
-        return;
     }
 }
 

--- a/src/vmcs/src/root_ept_intel_x64.cpp
+++ b/src/vmcs/src/root_ept_intel_x64.cpp
@@ -156,19 +156,14 @@ root_ept_intel_x64::map_page(integer_pointer gpa, integer_pointer phys, attr_typ
     switch (size)
     {
         case ept::pdpt::size_bytes:
-            entry.clear();
             entry.set_phys_addr(phys & ~(ept::pdpt::size_bytes - 1));
-            entry.set_entry_type(true);
             break;
 
         case ept::pd::size_bytes:
-            entry.clear();
             entry.set_phys_addr(phys & ~(ept::pd::size_bytes - 1));
-            entry.set_entry_type(true);
             break;
 
         case ept::pt::size_bytes:
-            entry.clear();
             entry.set_phys_addr(phys & ~(ept::pt::size_bytes - 1));
             break;
     }

--- a/src/vmcs/test/test.cpp
+++ b/src/vmcs/test/test.cpp
@@ -85,11 +85,14 @@ eapis_ut::list()
     this->test_ept_entry_intel_x64_pass_through_access();
     this->test_ept_entry_intel_x64_clear();
 
+    this->test_ept_intel_x64_get_entry();
     this->test_ept_intel_x64_add_remove_page_success_without_setting();
     this->test_ept_intel_x64_add_remove_page_1g_success();
     this->test_ept_intel_x64_add_remove_page_2m_success();
     this->test_ept_intel_x64_add_remove_page_4k_success();
-    this->test_ept_intel_x64_add_remove_page_swap_success();
+    this->test_ept_intel_x64_add_page_swap_1g_exception();
+    this->test_ept_intel_x64_add_page_swap_2m_exception();
+    this->test_ept_intel_x64_add_page_swap_4k_exception();
     this->test_ept_intel_x64_add_page_twice_success();
     this->test_ept_intel_x64_remove_page_twice_success();
     this->test_ept_intel_x64_remove_page_unknown_success();

--- a/src/vmcs/test/test.h
+++ b/src/vmcs/test/test.h
@@ -84,11 +84,14 @@ private:
     void test_ept_entry_intel_x64_pass_through_access();
     void test_ept_entry_intel_x64_clear();
 
+    void test_ept_intel_x64_get_entry();
     void test_ept_intel_x64_add_remove_page_success_without_setting();
     void test_ept_intel_x64_add_remove_page_1g_success();
     void test_ept_intel_x64_add_remove_page_2m_success();
     void test_ept_intel_x64_add_remove_page_4k_success();
-    void test_ept_intel_x64_add_remove_page_swap_success();
+    void test_ept_intel_x64_add_page_swap_1g_exception();
+    void test_ept_intel_x64_add_page_swap_2m_exception();
+    void test_ept_intel_x64_add_page_swap_4k_exception();
     void test_ept_intel_x64_add_page_twice_success();
     void test_ept_intel_x64_remove_page_twice_success();
     void test_ept_intel_x64_remove_page_unknown_success();


### PR DESCRIPTION
This patch fixes a few problems with ept_intel_64::add_page and
ept_intel_x64::remove_page:

Before adding any entry that mapped a page (i.e. in the base case),
add_page cleared the m_epts if it wasn't empty. This invalidated all
the entries in that table that mapped another table.

In the recursive step (when bits > end), add_page did not
check if the entry at that level was already mapped as a page.
So if a 2M page was mapped and then a 4K page was mapped in that
same 2M region, the 2M page entry was overwritten with one
that maps a page table.

Now add_page throws an exception if the user tries to map either a page
over an entry that maps a table or a table over an entry that
already maps a page. In order to enforce the latter case, add_page now
sets bit 7 whenever a base case is reached and throws an exception if
that bit is set in a recursive case.  So with this patch, the entry
returned from add_page is cleared except for bit 7.

Since the entry returned from add_page has only bit 7 set,
root_ept_intel_x64::map_page no longer calls entry.clear()
or entry.set_entry_type() (which toggles bit 7).

Before this patch, remove_page checked if the m_epts was
empty, and if it wasn't, removed the entry from the m_epts.
Only when the m_epts was empty did the page entry get
removed (in the 'else' branch of the !m_epts.empty() check).

So if e.g. a 2M page entry and a 4K table entry were in the same
page directory, a call to remove_page for the 2M page would
see that the m_epts was not empty (because of the 4K table entry)
and would bfn::find with the 2M entry's index, which would return
NULL because that region is mapped as a page. So the 'if' branch
would exit without doing anything and the page was never removed.

With this patch, remove_page checks if the entry maps a page first
and if so clears it and returns.  If the entry doesn't map a page,
then as before it recursively removes the table entry.