### PR TITLE
Add ignore write and ignore advance

### DIFF
--- a/include/hve/arch/intel_x64/msrs.h
+++ b/include/hve/arch/intel_x64/msrs.h
@@ -66,6 +66,8 @@ public:
     struct info_t {
         ::x64::msrs::field_type msr;    // In
         ::x64::msrs::value_type val;    // In / Out
+        bool ignore_write;              // Out
+        bool ignore_advance;            // Out
     };
 
     using rdmsr_handler_delegate_t =


### PR DESCRIPTION
This patch adds ignore_write and ignore_advance to the MSR delegates so
that the delegate can declare if it is hanlding the write or advance on
its own.

Signed-off-by: Rian Quinn <rianquinn@gmail.com>