### PR TITLE
Create interrupt_window exit handler

### DIFF
--- a/include/hve/arch/intel_x64/control_register.h
+++ b/include/hve/arch/intel_x64/control_register.h
@@ -30,7 +30,7 @@ namespace eapis
 namespace intel_x64
 {
 
-class vcpu;
+class hve;
 
 class EXPORT_EAPIS_HVE control_register : public base
 {
@@ -51,7 +51,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    control_register(gsl::not_null<eapis::intel_x64::vcpu *> vcpu);
+    control_register(gsl::not_null<eapis::intel_x64::hve *> hve);
 
     /// Destructor
     ///

--- a/include/hve/arch/intel_x64/cpuid.h
+++ b/include/hve/arch/intel_x64/cpuid.h
@@ -38,7 +38,7 @@ struct pair_hash {
     }
 };
 
-class vcpu;
+class hve;
 
 class EXPORT_EAPIS_HVE cpuid : public base
 {
@@ -64,7 +64,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    cpuid(gsl::not_null<eapis::intel_x64::vcpu *> vcpu);
+    cpuid(gsl::not_null<eapis::intel_x64::hve *> hve);
 
     /// Destructor
     ///

--- a/include/hve/arch/intel_x64/external_interrupt.h
+++ b/include/hve/arch/intel_x64/external_interrupt.h
@@ -30,7 +30,7 @@ namespace eapis
 namespace intel_x64
 {
 
-class vcpu;
+class hve;
 
 class EXPORT_EAPIS_HVE external_interrupt : public base
 {
@@ -48,7 +48,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    external_interrupt(gsl::not_null<eapis::intel_x64::vcpu *> vcpu);
+    external_interrupt(gsl::not_null<eapis::intel_x64::hve *> hve);
 
     /// Destructor
     ///

--- a/include/hve/arch/intel_x64/hve.h
+++ b/include/hve/arch/intel_x64/hve.h
@@ -24,6 +24,7 @@
 #include "control_register.h"
 #include "cpuid.h"
 #include "external_interrupt.h"
+#include "interrupt_window.h"
 #include "io_instruction.h"
 #include "monitor_trap.h"
 #include "mov_dr.h"
@@ -194,6 +195,26 @@ public:
     ///
     void add_external_interrupt_handler(
         vmcs_n::value_type v, external_interrupt::handler_delegate_t &&d);
+
+    //--------------------------------------------------------------------------
+    // Interrupt Window
+    //--------------------------------------------------------------------------
+
+    /// Get Interrupt Window Object
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @return Returns the interrupt window object stored in the hve if
+    ///
+    gsl::not_null<interrupt_window *> interrupt_window();
+
+    /// Add Interrupt Window Handler
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    void add_interrupt_window_handler(interrupt_window::handler_delegate_t &&d);
 
     //--------------------------------------------------------------------------
     // IO Instruction
@@ -391,6 +412,7 @@ private:
     std::unique_ptr<eapis::intel_x64::control_register> m_control_register;
     std::unique_ptr<eapis::intel_x64::cpuid> m_cpuid;
     std::unique_ptr<eapis::intel_x64::external_interrupt> m_external_interrupt;
+    std::unique_ptr<eapis::intel_x64::interrupt_window> m_interrupt_window;
     std::unique_ptr<eapis::intel_x64::io_instruction> m_io_instruction;
     std::unique_ptr<eapis::intel_x64::monitor_trap> m_monitor_trap;
     std::unique_ptr<eapis::intel_x64::mov_dr> m_mov_dr;

--- a/include/hve/arch/intel_x64/hve.h
+++ b/include/hve/arch/intel_x64/hve.h
@@ -16,10 +16,9 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#ifndef VCPU_INTEL_X64_EAPIS_H
-#define VCPU_INTEL_X64_EAPIS_H
+#ifndef HVE_INTEL_X64_EAPIS_H
+#define HVE_INTEL_X64_EAPIS_H
 
-#include <bfvmm/hve/arch/intel_x64/vcpu/vcpu.h>
 #include <bfvmm/memory_manager/memory_manager.h>
 
 #include "control_register.h"
@@ -37,26 +36,47 @@ namespace eapis
 namespace intel_x64
 {
 
-class vcpu : public bfvmm::intel_x64::vcpu
+class hve
 {
 
 public:
 
-    /// Default Constructor
+    /// Constructor
     ///
     /// @expects
     /// @ensures
     ///
-    vcpu(vcpuid::type id);
+    hve(
+        gsl::not_null<exit_handler_t *> exit_handler,
+        gsl::not_null<vmcs_t *> vmcs
+    );
 
     /// Destructor
     ///
     /// @expects
     /// @ensures
     ///
-    ~vcpu() = default;
+    ~hve() = default;
 
 public:
+
+    /// Get Exit Handler Object
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @return Returns the exit handler object stored in this hve
+    ///
+    gsl::not_null<exit_handler_t *> exit_handler();
+
+    /// Get VMCS Object
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @return Returns the vmcs object stored in this hve
+    ///
+    gsl::not_null<vmcs_t *> vmcs();
 
     //--------------------------------------------------------------------------
     // Control Register
@@ -67,7 +87,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    /// @return Returns the CR object stored in the vCPU if CR trapping is
+    /// @return Returns the CR object stored in the hve if CR trapping is
     ///     enabled, otherwise an exception is thrown
     ///
     gsl::not_null<control_register *> control_register();
@@ -139,7 +159,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    /// @return Returns the CPUID object stored in the vCPU if CPUID trapping is
+    /// @return Returns the CPUID object stored in the hve if CPUID trapping is
     ///     enabled, otherwise an exception is thrown
     ///
     gsl::not_null<cpuid *> cpuid();
@@ -161,7 +181,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    /// @return Returns the external interrupt object stored in the vCPU if
+    /// @return Returns the external interrupt object stored in the hve if
     ///     external-interrupt exiting is enabled, otherwise an exception is
     ///     thrown
     ///
@@ -184,7 +204,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    /// @return Returns the IO Instruction object stored in the vCPU if IO
+    /// @return Returns the IO Instruction object stored in the hve if IO
     ///     Instruction trapping is enabled, otherwise an exception is thrown
     ///
     gsl::not_null<io_instruction *> io_instruction();
@@ -208,7 +228,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    /// @return Returns the Monitor Trap object stored in the vCPU if Monitor
+    /// @return Returns the Monitor Trap object stored in the hve if Monitor
     ///     Trap is enabled, otherwise an exception is thrown
     ///
     gsl::not_null<monitor_trap *> monitor_trap();
@@ -236,7 +256,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    /// @return Returns the Move DR object stored in the vCPU if Move DR
+    /// @return Returns the Move DR object stored in the hve if Move DR
     ///     trapping is enabled, otherwise an exception is thrown
     ///
     gsl::not_null<mov_dr *> mov_dr();
@@ -257,7 +277,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    /// @return Returns the Read MSR object stored in the vCPU if Read MSR
+    /// @return Returns the Read MSR object stored in the hve if Read MSR
     ///     trapping is enabled, otherwise an exception is thrown
     ///
     gsl::not_null<rdmsr *> rdmsr();
@@ -286,7 +306,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    /// @return Returns the VPID object stored in the vCPU if VPID trapping is
+    /// @return Returns the VPID object stored in the hve if VPID trapping is
     ///     enabled, otherwise an exception is thrown
     ///
     gsl::not_null<vpid *> vpid();
@@ -307,7 +327,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    /// @return Returns the Write MSR object stored in the vCPU if Write MSR
+    /// @return Returns the Write MSR object stored in the hve if Write MSR
     ///     trapping is enabled, otherwise an exception is thrown
     ///
     gsl::not_null<wrmsr *> wrmsr();
@@ -377,6 +397,9 @@ private:
     std::unique_ptr<eapis::intel_x64::rdmsr> m_rdmsr;
     std::unique_ptr<eapis::intel_x64::vpid> m_vpid;
     std::unique_ptr<eapis::intel_x64::wrmsr> m_wrmsr;
+
+    exit_handler_t *m_exit_handler;
+    vmcs_t *m_vmcs;
 };
 
 }

--- a/include/hve/arch/intel_x64/interrupt_window.h
+++ b/include/hve/arch/intel_x64/interrupt_window.h
@@ -1,0 +1,145 @@
+//
+// Bareflank Extended APIs
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef INTERRUPT_WINDOW_INTEL_X64_EAPIS_H
+#define INTERRUPT_WINDOW_INTEL_X64_EAPIS_H
+
+#include "base.h"
+
+// -----------------------------------------------------------------------------
+// Definitions
+// -----------------------------------------------------------------------------
+
+namespace eapis
+{
+namespace intel_x64
+{
+
+class hve;
+
+class EXPORT_EAPIS_HVE interrupt_window : public base
+{
+public:
+
+    using handler_delegate_t = delegate<bool(gsl::not_null<vmcs_t *>)>;
+
+    /// Constructor
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    interrupt_window(gsl::not_null<eapis::intel_x64::hve *> hve);
+
+    /// Destructor
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    ~interrupt_window() = default;
+
+public:
+
+    /// Add Handler
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @param vector the vector to listen to
+    /// @param d the handler to call when an exit occurs
+    ///
+    void add_handler(handler_delegate_t &&d);
+
+    /// Enable exiting
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    void enable_exiting();
+
+    /// Disable exiting
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    void disable_exiting();
+
+    /// Is open
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    ///
+    bool is_open();
+
+    /// Inject
+    ///
+    /// Inject an external interrupt at the given vector on the upcoming
+    /// VM-entry
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @param vector the vector to inject into the VM
+    ///
+    void inject(uint64_t vector);
+
+public:
+
+    /// Dump Log
+    ///
+    /// Example:
+    /// @code
+    /// this->dump_log();
+    /// @endcode
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    void dump_log() final;
+
+    /// @cond
+
+    bool handle(gsl::not_null<vmcs_t *> vmcs);
+
+    /// @endcond
+
+private:
+
+    /// @cond
+
+    std::list<handler_delegate_t> m_handlers{};
+
+    /// @endcond
+
+public:
+
+    /// @cond
+
+    interrupt_window(interrupt_window &&) = default;
+    interrupt_window &operator=(interrupt_window &&) = default;
+
+    interrupt_window(const interrupt_window &) = delete;
+    interrupt_window &operator=(const interrupt_window &) = delete;
+
+    /// @endcond
+};
+
+}
+}
+
+#endif

--- a/include/hve/arch/intel_x64/io_instruction.h
+++ b/include/hve/arch/intel_x64/io_instruction.h
@@ -30,7 +30,7 @@ namespace eapis
 namespace intel_x64
 {
 
-class vcpu;
+class hve;
 
 class EXPORT_EAPIS_HVE io_instruction : public base
 {
@@ -53,7 +53,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    io_instruction(gsl::not_null<eapis::intel_x64::vcpu *> vcpu);
+    io_instruction(gsl::not_null<eapis::intel_x64::hve *> hve);
 
     /// Destructor
     ///

--- a/include/hve/arch/intel_x64/monitor_trap.h
+++ b/include/hve/arch/intel_x64/monitor_trap.h
@@ -30,7 +30,7 @@ namespace eapis
 namespace intel_x64
 {
 
-class vcpu;
+class hve;
 
 class EXPORT_EAPIS_HVE monitor_trap : public base
 {
@@ -48,7 +48,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    monitor_trap(gsl::not_null<eapis::intel_x64::vcpu *> vcpu);
+    monitor_trap(gsl::not_null<eapis::intel_x64::hve *> hve);
 
     /// Destructor
     ///

--- a/include/hve/arch/intel_x64/mov_dr.h
+++ b/include/hve/arch/intel_x64/mov_dr.h
@@ -30,7 +30,7 @@ namespace eapis
 namespace intel_x64
 {
 
-class vcpu;
+class hve;
 
 class EXPORT_EAPIS_HVE mov_dr : public base
 {
@@ -50,7 +50,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    mov_dr(gsl::not_null<eapis::intel_x64::vcpu *> vcpu);
+    mov_dr(gsl::not_null<eapis::intel_x64::hve *> hve);
 
     /// Destructor
     ///

--- a/include/hve/arch/intel_x64/rdmsr.h
+++ b/include/hve/arch/intel_x64/rdmsr.h
@@ -30,7 +30,7 @@ namespace eapis
 namespace intel_x64
 {
 
-class vcpu;
+class hve;
 
 class EXPORT_EAPIS_HVE rdmsr : public base
 {
@@ -51,7 +51,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    rdmsr(gsl::not_null<eapis::intel_x64::vcpu *> vcpu);
+    rdmsr(gsl::not_null<eapis::intel_x64::hve *> hve);
 
     /// Destructor
     ///

--- a/include/hve/arch/intel_x64/wrmsr.h
+++ b/include/hve/arch/intel_x64/wrmsr.h
@@ -30,7 +30,7 @@ namespace eapis
 namespace intel_x64
 {
 
-class vcpu;
+class hve;
 
 class EXPORT_EAPIS_HVE wrmsr : public base
 {
@@ -51,7 +51,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    wrmsr(gsl::not_null<eapis::intel_x64::vcpu *> vcpu);
+    wrmsr(gsl::not_null<eapis::intel_x64::hve *> hve);
 
     /// Destructor
     ///

--- a/include/vcpu/arch/intel_x64/vcpu.h
+++ b/include/vcpu/arch/intel_x64/vcpu.h
@@ -16,33 +16,32 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/vcpu/arch/intel_x64/vcpu.h>
+#ifndef VCPU_INTEL_X64_EAPIS_H
+#define VCPU_INTEL_X64_EAPIS_H
 
-using namespace eapis::intel_x64;
+#include <bfvmm/hve/arch/intel_x64/vcpu/vcpu.h>
 
-// -----------------------------------------------------------------------------
-// vCPU
-// -----------------------------------------------------------------------------
+#include "../../../hve/arch/intel_x64/hve.h"
 
-namespace test
+namespace eapis
+{
+namespace intel_x64
 {
 
-class vcpu : public eapis::intel_x64::vcpu
+class vcpu : public bfvmm::intel_x64::vcpu
 {
+
 public:
 
-    /// Default Constructor
+    /// Constructor
     ///
     /// @expects
     /// @ensures
     ///
     vcpu(vcpuid::type id) :
-        eapis::intel_x64::vcpu{id}
-    {
-        hve()->enable_vpid();
-        bfdebug_nhex(0, "vpid", hve()->vpid()->id());
-    }
+        bfvmm::intel_x64::vcpu{id},
+        m_hve{std::make_unique<eapis::intel_x64::hve>(exit_handler(), vmcs())}
+    { }
 
     /// Destructor
     ///
@@ -50,22 +49,27 @@ public:
     /// @ensures
     ///
     ~vcpu() = default;
+
+    /// Get HVE (hardware virtualization extensions)
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @return Returns the hve object stored in this vCPU
+    ///
+    gsl::not_null<eapis::intel_x64::hve *> hve()
+    { return m_hve.get(); }
+
+private:
+
+    /// @cond
+
+    std::unique_ptr<eapis::intel_x64::hve> m_hve;
+
+    /// @endcond
 };
 
 }
-
-// -----------------------------------------------------------------------------
-// vCPU Factory
-// -----------------------------------------------------------------------------
-
-namespace bfvmm
-{
-
-std::unique_ptr<vcpu>
-vcpu_factory::make_vcpu(vcpuid::type vcpuid, bfobject *obj)
-{
-    bfignored(obj);
-    return std::make_unique<test::vcpu>(vcpuid);
 }
 
-}
+#endif

--- a/integration/arch/intel_x64/control_register/CMakeLists.txt
+++ b/integration/arch/intel_x64/control_register/CMakeLists.txt
@@ -20,28 +20,30 @@ cmake_minimum_required(VERSION 3.6)
 project(eapis_main C CXX)
 
 include(${SOURCE_CMAKE_DIR}/project.cmake)
-init_project()
+init_project(
+    INCLUDES ../../../../include
+)
 
 add_vmm_executable(
     eapis_integration_intel_x64_control_register_trap_cr0
-    SOURCES trap_cr0.cpp
+    SOURCES trap_cr0.cpp ../../../../src/vcpu/arch/intel_x64/vcpu.cpp
     LIBRARIES eapis_hve
 )
 
 add_vmm_executable(
     eapis_integration_intel_x64_control_register_trap_cr3
-    SOURCES trap_cr3.cpp
+    SOURCES trap_cr3.cpp ../../../../src/vcpu/arch/intel_x64/vcpu.cpp
     LIBRARIES eapis_hve
 )
 
 add_vmm_executable(
     eapis_integration_intel_x64_control_register_trap_cr4
-    SOURCES trap_cr4.cpp
+    SOURCES trap_cr4.cpp ../../../../src/vcpu/arch/intel_x64/vcpu.cpp
     LIBRARIES eapis_hve
 )
 
 add_vmm_executable(
     eapis_integration_intel_x64_control_register_trap_cr8
-    SOURCES trap_cr8.cpp
+    SOURCES trap_cr8.cpp ../../../../src/vcpu/arch/intel_x64/vcpu.cpp
     LIBRARIES eapis_hve
 )

--- a/integration/arch/intel_x64/control_register/trap_cr0.cpp
+++ b/integration/arch/intel_x64/control_register/trap_cr0.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/hve/arch/intel_x64/vcpu.h>
+#include <eapis/vcpu/arch/intel_x64/vcpu.h>
 
 using namespace eapis::intel_x64;
 
@@ -54,15 +54,15 @@ public:
     vcpu(vcpuid::type id) :
         eapis::intel_x64::vcpu{id}
     {
-        this->enable_wrcr0_exiting(
+        hve()->enable_wrcr0_exiting(
             0xFFFFFFFFFFFFFFFF, ::intel_x64::vmcs::guest_cr0::get()
         );
 
-        this->add_wrcr0_handler(
+        hve()->add_wrcr0_handler(
             control_register::handler_delegate_t::create<test_handler>()
         );
 
-        control_register()->enable_log();
+        hve()->control_register()->enable_log();
     }
 
     /// Destructor

--- a/integration/arch/intel_x64/control_register/trap_cr3.cpp
+++ b/integration/arch/intel_x64/control_register/trap_cr3.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/hve/arch/intel_x64/vcpu.h>
+#include <eapis/vcpu/arch/intel_x64/vcpu.h>
 
 using namespace eapis::intel_x64;
 
@@ -49,15 +49,15 @@ public:
     vcpu(vcpuid::type id) :
         eapis::intel_x64::vcpu{id}
     {
-        this->add_rdcr3_handler(
+        hve()->add_rdcr3_handler(
             control_register::handler_delegate_t::create<test_handler>()
         );
 
-        this->add_wrcr3_handler(
+        hve()->add_wrcr3_handler(
             control_register::handler_delegate_t::create<test_handler>()
         );
 
-        control_register()->enable_log();
+        hve()->control_register()->enable_log();
     }
 
     /// Destructor

--- a/integration/arch/intel_x64/control_register/trap_cr4.cpp
+++ b/integration/arch/intel_x64/control_register/trap_cr4.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/hve/arch/intel_x64/vcpu.h>
+#include <eapis/vcpu/arch/intel_x64/vcpu.h>
 
 using namespace eapis::intel_x64;
 
@@ -56,15 +56,15 @@ public:
     vcpu(vcpuid::type id) :
         eapis::intel_x64::vcpu{id}
     {
-        this->enable_wrcr4_exiting(
+        hve()->enable_wrcr4_exiting(
             0xFFFFFFFFFFFFFFFF, ::intel_x64::vmcs::guest_cr4::get()
         );
 
-        this->add_wrcr4_handler(
+        hve()->add_wrcr4_handler(
             control_register::handler_delegate_t::create<test_handler>()
         );
 
-        control_register()->enable_log();
+        hve()->control_register()->enable_log();
     }
 
     /// Destructor

--- a/integration/arch/intel_x64/control_register/trap_cr8.cpp
+++ b/integration/arch/intel_x64/control_register/trap_cr8.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/hve/arch/intel_x64/vcpu.h>
+#include <eapis/vcpu/arch/intel_x64/vcpu.h>
 
 using namespace eapis::intel_x64;
 
@@ -42,15 +42,15 @@ public:
     {
         m_tpr_shadow = ::intel_x64::cr8::get();
 
-        this->add_rdcr8_handler(
+        hve()->add_rdcr8_handler(
             control_register::handler_delegate_t::create<vcpu, &vcpu::test_rdcr8_handler>(this)
         );
 
-        this->add_wrcr8_handler(
+        hve()->add_wrcr8_handler(
             control_register::handler_delegate_t::create<vcpu, &vcpu::test_wrcr8_handler>(this)
         );
 
-        control_register()->enable_log();
+        hve()->control_register()->enable_log();
     }
 
     /// Destructor

--- a/integration/arch/intel_x64/cpuid/CMakeLists.txt
+++ b/integration/arch/intel_x64/cpuid/CMakeLists.txt
@@ -20,10 +20,12 @@ cmake_minimum_required(VERSION 3.6)
 project(eapis_main C CXX)
 
 include(${SOURCE_CMAKE_DIR}/project.cmake)
-init_project()
+init_project(
+    INCLUDES ../../../../include
+)
 
 add_vmm_executable(
     eapis_integration_intel_x64_cpuid_trap_cpuid
-    SOURCES trap_cpuid.cpp
+    SOURCES trap_cpuid.cpp ../../../../src/vcpu/arch/intel_x64/vcpu.cpp
     LIBRARIES eapis_hve
 )

--- a/integration/arch/intel_x64/cpuid/trap_cpuid.cpp
+++ b/integration/arch/intel_x64/cpuid/trap_cpuid.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/hve/arch/intel_x64/vcpu.h>
+#include <eapis/vcpu/arch/intel_x64/vcpu.h>
 
 using namespace eapis::intel_x64;
 
@@ -58,11 +58,11 @@ public:
     vcpu(vcpuid::type id) :
         eapis::intel_x64::vcpu{id}
     {
-        this->add_cpuid_handler(
+        hve()->add_cpuid_handler(
             42, 0, cpuid::handler_delegate_t::create<test_handler>()
         );
 
-        cpuid()->enable_log();
+        hve()->cpuid()->enable_log();
     }
 
     /// Destructor

--- a/integration/arch/intel_x64/io_instruction/CMakeLists.txt
+++ b/integration/arch/intel_x64/io_instruction/CMakeLists.txt
@@ -20,10 +20,12 @@ cmake_minimum_required(VERSION 3.6)
 project(eapis_main C CXX)
 
 include(${SOURCE_CMAKE_DIR}/project.cmake)
-init_project()
+init_project(
+    INCLUDES ../../../../include
+)
 
 add_vmm_executable(
     eapis_integration_intel_x64_io_instruction_trap_in_out
-    SOURCES trap_in_out.cpp
+    SOURCES trap_in_out.cpp ../../../../src/vcpu/arch/intel_x64/vcpu.cpp
     LIBRARIES eapis_hve
 )

--- a/integration/arch/intel_x64/io_instruction/trap_in_out.cpp
+++ b/integration/arch/intel_x64/io_instruction/trap_in_out.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/hve/arch/intel_x64/vcpu.h>
+#include <eapis/vcpu/arch/intel_x64/vcpu.h>
 
 using namespace eapis::intel_x64;
 
@@ -49,19 +49,19 @@ public:
     vcpu(vcpuid::type id) :
         eapis::intel_x64::vcpu{id}
     {
-        this->add_io_instruction_handler(
+        hve()->add_io_instruction_handler(
             0xCF8,
             io_instruction::handler_delegate_t::create<test_handler>(),
             io_instruction::handler_delegate_t::create<test_handler>()
         );
 
-        this->add_io_instruction_handler(
+        hve()->add_io_instruction_handler(
             0xCFC,
             io_instruction::handler_delegate_t::create<test_handler>(),
             io_instruction::handler_delegate_t::create<test_handler>()
         );
 
-        io_instruction()->enable_log();
+        hve()->io_instruction()->enable_log();
     }
 
     /// Destructor

--- a/integration/arch/intel_x64/monitor_trap/CMakeLists.txt
+++ b/integration/arch/intel_x64/monitor_trap/CMakeLists.txt
@@ -20,7 +20,9 @@ cmake_minimum_required(VERSION 3.6)
 project(eapis_main C CXX)
 
 include(${SOURCE_CMAKE_DIR}/project.cmake)
-init_project()
+init_project(
+    INCLUDES ../../../../include
+)
 
 add_vmm_executable(
     eapis_integration_intel_x64_monitor_trap_single_step_cpuid

--- a/integration/arch/intel_x64/monitor_trap/single_step_cpuid.cpp
+++ b/integration/arch/intel_x64/monitor_trap/single_step_cpuid.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/hve/arch/intel_x64/vcpu.h>
+#include <eapis/vcpu/arch/intel_x64/vcpu.h>
 
 using namespace eapis::intel_x64;
 
@@ -40,12 +40,12 @@ public:
     vcpu(vcpuid::type id) :
         eapis::intel_x64::vcpu{id}
     {
-        this->add_cpuid_handler(
+        hve()->add_cpuid_handler(
             42, 0,
             cpuid::handler_delegate_t::create<vcpu, &vcpu::cpuid_handler>(this)
         );
 
-        this->add_monitor_trap_handler(
+        hve()->add_monitor_trap_handler(
             monitor_trap::handler_delegate_t::create<vcpu, &vcpu::monitor_trap_handler>(this)
         );
     }
@@ -70,7 +70,7 @@ public:
         info.rcx = 42;
         info.rdx = 42;
 
-        this->enable_monitor_trap_flag();
+        hve()->enable_monitor_trap_flag();
         return false;
     }
 

--- a/integration/arch/intel_x64/mov_dr/CMakeLists.txt
+++ b/integration/arch/intel_x64/mov_dr/CMakeLists.txt
@@ -20,7 +20,9 @@ cmake_minimum_required(VERSION 3.6)
 project(eapis_main C CXX)
 
 include(${SOURCE_CMAKE_DIR}/project.cmake)
-init_project()
+init_project(
+    INCLUDES ../../../../include
+)
 
 add_vmm_executable(
     eapis_integration_intel_x64_drs_trap_dr7

--- a/integration/arch/intel_x64/mov_dr/trap_dr7.cpp
+++ b/integration/arch/intel_x64/mov_dr/trap_dr7.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/hve/arch/intel_x64/vcpu.h>
+#include <eapis/vcpu/arch/intel_x64/vcpu.h>
 
 using namespace eapis::intel_x64;
 
@@ -49,11 +49,11 @@ public:
     vcpu(vcpuid::type id) :
         eapis::intel_x64::vcpu{id}
     {
-        this->add_mov_dr_handler(
+        hve()->add_mov_dr_handler(
             mov_dr::handler_delegate_t::create<test_handler>()
         );
 
-        mov_dr()->enable_log();
+        hve()->mov_dr()->enable_log();
     }
 
     /// Destructor

--- a/integration/arch/intel_x64/rdmsr/CMakeLists.txt
+++ b/integration/arch/intel_x64/rdmsr/CMakeLists.txt
@@ -20,10 +20,12 @@ cmake_minimum_required(VERSION 3.6)
 project(eapis_main C CXX)
 
 include(${SOURCE_CMAKE_DIR}/project.cmake)
-init_project()
+init_project(
+    INCLUDES ../../../../include
+)
 
 add_vmm_executable(
     eapis_integration_intel_x64_rdmsr_trap_rdmsr_vmm
-    SOURCES trap_rdmsr.cpp
+    SOURCES trap_rdmsr.cpp ../../../../src/vcpu/arch/intel_x64/vcpu.cpp
     LIBRARIES eapis_hve
 )

--- a/integration/arch/intel_x64/rdmsr/trap_rdmsr.cpp
+++ b/integration/arch/intel_x64/rdmsr/trap_rdmsr.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/hve/arch/intel_x64/vcpu.h>
+#include <eapis/vcpu/arch/intel_x64/vcpu.h>
 
 using namespace eapis::intel_x64;
 
@@ -49,12 +49,12 @@ public:
     vcpu(vcpuid::type id) :
         eapis::intel_x64::vcpu{id}
     {
-        this->add_rdmsr_handler(
+        hve()->add_rdmsr_handler(
             0x000000000000003B,
             rdmsr::handler_delegate_t::create<test_handler>()
         );
 
-        rdmsr()->enable_log();
+        hve()->rdmsr()->enable_log();
     }
 
     /// Destructor

--- a/integration/arch/intel_x64/vpid/CMakeLists.txt
+++ b/integration/arch/intel_x64/vpid/CMakeLists.txt
@@ -20,7 +20,9 @@ cmake_minimum_required(VERSION 3.6)
 project(eapis_main C CXX)
 
 include(${SOURCE_CMAKE_DIR}/project.cmake)
-init_project()
+init_project(
+    INCLUDES ../../../../include
+)
 
 add_vmm_executable(
     eapis_integration_intel_x64_vpid_enable_vpid

--- a/integration/arch/intel_x64/wrmsr/CMakeLists.txt
+++ b/integration/arch/intel_x64/wrmsr/CMakeLists.txt
@@ -20,10 +20,12 @@ cmake_minimum_required(VERSION 3.6)
 project(eapis_main C CXX)
 
 include(${SOURCE_CMAKE_DIR}/project.cmake)
-init_project()
+init_project(
+    INCLUDES ../../../../include
+)
 
 add_vmm_executable(
     eapis_integration_intel_x64_wrmsr_trap_wrmsr_vmm
-    SOURCES trap_wrmsr.cpp
+    SOURCES trap_wrmsr.cpp ../../../../src/vcpu/arch/intel_x64/vcpu.cpp
     LIBRARIES eapis_hve
 )

--- a/integration/arch/intel_x64/wrmsr/trap_wrmsr.cpp
+++ b/integration/arch/intel_x64/wrmsr/trap_wrmsr.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/hve/arch/intel_x64/vcpu.h>
+#include <eapis/vcpu/arch/intel_x64/vcpu.h>
 
 using namespace eapis::intel_x64;
 
@@ -49,12 +49,12 @@ public:
     vcpu(vcpuid::type id) :
         eapis::intel_x64::vcpu{id}
     {
-        this->add_wrmsr_handler(
+        hve()->add_wrmsr_handler(
             0x000000000000080B,
             wrmsr::handler_delegate_t::create<test_handler>()
         );
 
-        wrmsr()->enable_log();
+        hve()->wrmsr()->enable_log();
     }
 
     /// Destructor

--- a/src/hve/CMakeLists.txt
+++ b/src/hve/CMakeLists.txt
@@ -21,6 +21,7 @@ if(${BUILD_TARGET_ARCH} STREQUAL "x86_64")
         arch/intel_x64/control_register.cpp
         arch/intel_x64/cpuid.cpp
         arch/intel_x64/external_interrupt.cpp
+        arch/intel_x64/interrupt_window.cpp
         arch/intel_x64/io_instruction.cpp
         arch/intel_x64/monitor_trap.cpp
         arch/intel_x64/mov_dr.cpp

--- a/src/hve/CMakeLists.txt
+++ b/src/hve/CMakeLists.txt
@@ -25,9 +25,9 @@ if(${BUILD_TARGET_ARCH} STREQUAL "x86_64")
         arch/intel_x64/monitor_trap.cpp
         arch/intel_x64/mov_dr.cpp
         arch/intel_x64/rdmsr.cpp
-        arch/intel_x64/vcpu.cpp
         arch/intel_x64/vpid.cpp
         arch/intel_x64/wrmsr.cpp
+        arch/intel_x64/hve.cpp
     )
 elseif(${BUILD_TARGET_ARCH} STREQUAL "aarch64")
     message(WARNING "Unimplemented")

--- a/src/hve/arch/intel_x64/control_register.cpp
+++ b/src/hve/arch/intel_x64/control_register.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfdebug.h>
-#include <hve/arch/intel_x64/vcpu.h>
+#include <hve/arch/intel_x64/hve.h>
 
 namespace eapis
 {
@@ -30,9 +30,9 @@ default_handler(
 { bfignored(vmcs); bfignored(info); return true; }
 
 control_register::control_register(
-    gsl::not_null<eapis::intel_x64::vcpu *> vcpu
+    gsl::not_null<eapis::intel_x64::hve *> hve
 ) :
-    m_exit_handler{vcpu->exit_handler()}
+    m_exit_handler{hve->exit_handler()}
 {
     using namespace vmcs_n;
 

--- a/src/hve/arch/intel_x64/cpuid.cpp
+++ b/src/hve/arch/intel_x64/cpuid.cpp
@@ -17,15 +17,15 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfdebug.h>
-#include <hve/arch/intel_x64/vcpu.h>
+#include <hve/arch/intel_x64/hve.h>
 
 namespace eapis
 {
 namespace intel_x64
 {
 
-cpuid::cpuid(gsl::not_null<eapis::intel_x64::vcpu *> vcpu) :
-    m_exit_handler{vcpu->exit_handler()}
+cpuid::cpuid(gsl::not_null<eapis::intel_x64::hve *> hve) :
+    m_exit_handler{hve->exit_handler()}
 {
     using namespace vmcs_n;
 

--- a/src/hve/arch/intel_x64/external_interrupt.cpp
+++ b/src/hve/arch/intel_x64/external_interrupt.cpp
@@ -17,18 +17,18 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfdebug.h>
-#include <hve/arch/intel_x64/vcpu.h>
+#include <hve/arch/intel_x64/hve.h>
 
 namespace eapis
 {
 namespace intel_x64
 {
 
-external_interrupt::external_interrupt(gsl::not_null<eapis::intel_x64::vcpu *> vcpu)
+external_interrupt::external_interrupt(gsl::not_null<eapis::intel_x64::hve *> hve)
 {
     using namespace vmcs_n;
 
-    vcpu->exit_handler()->add_handler(
+    hve->exit_handler()->add_handler(
         exit_reason::basic_exit_reason::external_interrupt,
         ::handler_delegate_t::create<external_interrupt, &external_interrupt::handle>(this)
     );

--- a/src/hve/arch/intel_x64/hve.cpp
+++ b/src/hve/arch/intel_x64/hve.cpp
@@ -134,6 +134,23 @@ void hve::add_external_interrupt_handler(
 }
 
 //--------------------------------------------------------------------------
+// Interrupt Window
+//--------------------------------------------------------------------------
+
+gsl::not_null<interrupt_window *> hve::interrupt_window()
+{ return m_interrupt_window.get(); }
+
+void hve::add_interrupt_window_handler(interrupt_window::handler_delegate_t &&d)
+{
+    if (!m_interrupt_window) {
+        m_interrupt_window =
+            std::make_unique<eapis::intel_x64::interrupt_window>(this);
+    }
+
+    m_interrupt_window->add_handler(std::move(d));
+}
+
+//--------------------------------------------------------------------------
 // IO Instruction
 //--------------------------------------------------------------------------
 

--- a/src/hve/arch/intel_x64/hve.cpp
+++ b/src/hve/arch/intel_x64/hve.cpp
@@ -16,72 +16,83 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include <bfvmm/hve/arch/intel_x64/vcpu/vcpu.h>
 #include <bfvmm/memory_manager/memory_manager.h>
 
-#include <hve/arch/intel_x64/vcpu.h>
+#include <hve/arch/intel_x64/hve.h>
 
 namespace eapis
 {
 namespace intel_x64
 {
 
-vcpu::vcpu(vcpuid::type id) :
-    bfvmm::intel_x64::vcpu{id}
+hve::hve(
+    gsl::not_null<exit_handler_t *> exit_handler,
+    gsl::not_null<vmcs_t *> vmcs
+) :
+    m_exit_handler{exit_handler},
+    m_vmcs{vmcs}
 { }
+
+gsl::not_null<exit_handler_t *>
+hve::exit_handler()
+{ return m_exit_handler; }
+
+gsl::not_null<vmcs_t *>
+hve::vmcs()
+{ return m_vmcs; }
 
 //--------------------------------------------------------------------------
 // Control Register
 //--------------------------------------------------------------------------
 
-gsl::not_null<control_register *> vcpu::control_register()
+gsl::not_null<control_register *> hve::control_register()
 { return m_control_register.get(); }
 
-void vcpu::enable_wrcr0_exiting(
+void hve::enable_wrcr0_exiting(
     vmcs_n::value_type mask, vmcs_n::value_type shadow)
 {
     check_crall();
     m_control_register->enable_wrcr0_exiting(mask, shadow);
 }
 
-void vcpu::enable_wrcr4_exiting(
+void hve::enable_wrcr4_exiting(
     vmcs_n::value_type mask, vmcs_n::value_type shadow)
 {
     check_crall();
     m_control_register->enable_wrcr4_exiting(mask, shadow);
 }
 
-void vcpu::add_wrcr0_handler(control_register::handler_delegate_t &&d)
+void hve::add_wrcr0_handler(control_register::handler_delegate_t &&d)
 {
     check_crall();
     m_control_register->add_wrcr0_handler(std::move(d));
 }
 
-void vcpu::add_rdcr3_handler(control_register::handler_delegate_t &&d)
+void hve::add_rdcr3_handler(control_register::handler_delegate_t &&d)
 {
     check_rdcr3();
     m_control_register->add_rdcr3_handler(std::move(d));
 }
 
-void vcpu::add_wrcr3_handler(control_register::handler_delegate_t &&d)
+void hve::add_wrcr3_handler(control_register::handler_delegate_t &&d)
 {
     check_wrcr3();
     m_control_register->add_wrcr3_handler(std::move(d));
 }
 
-void vcpu::add_wrcr4_handler(control_register::handler_delegate_t &&d)
+void hve::add_wrcr4_handler(control_register::handler_delegate_t &&d)
 {
     check_crall();
     m_control_register->add_wrcr4_handler(std::move(d));
 }
 
-void vcpu::add_rdcr8_handler(control_register::handler_delegate_t &&d)
+void hve::add_rdcr8_handler(control_register::handler_delegate_t &&d)
 {
     check_rdcr8();
     m_control_register->add_rdcr8_handler(std::move(d));
 }
 
-void vcpu::add_wrcr8_handler(control_register::handler_delegate_t &&d)
+void hve::add_wrcr8_handler(control_register::handler_delegate_t &&d)
 {
     check_wrcr8();
     m_control_register->add_wrcr8_handler(std::move(d));
@@ -91,10 +102,10 @@ void vcpu::add_wrcr8_handler(control_register::handler_delegate_t &&d)
 // CPUID
 //--------------------------------------------------------------------------
 
-gsl::not_null<cpuid *> vcpu::cpuid()
+gsl::not_null<cpuid *> hve::cpuid()
 { return m_cpuid.get(); }
 
-void vcpu::add_cpuid_handler(
+void hve::add_cpuid_handler(
     cpuid::leaf_t leaf, cpuid::subleaf_t subleaf, cpuid::handler_delegate_t &&d)
 {
     if (!m_cpuid) {
@@ -108,10 +119,10 @@ void vcpu::add_cpuid_handler(
 // External Interrupt
 //--------------------------------------------------------------------------
 
-gsl::not_null<external_interrupt *> vcpu::external_interrupt()
+gsl::not_null<external_interrupt *> hve::external_interrupt()
 { return m_external_interrupt.get(); }
 
-void vcpu::add_external_interrupt_handler(
+void hve::add_external_interrupt_handler(
     vmcs_n::value_type vector, external_interrupt::handler_delegate_t &&d)
 {
     if (!m_external_interrupt) {
@@ -126,10 +137,10 @@ void vcpu::add_external_interrupt_handler(
 // IO Instruction
 //--------------------------------------------------------------------------
 
-gsl::not_null<io_instruction *> vcpu::io_instruction()
+gsl::not_null<io_instruction *> hve::io_instruction()
 { return m_io_instruction.get(); }
 
-void vcpu::add_io_instruction_handler(
+void hve::add_io_instruction_handler(
     vmcs_n::value_type port,
     io_instruction::handler_delegate_t &&in_d,
     io_instruction::handler_delegate_t &&out_d)
@@ -147,16 +158,16 @@ void vcpu::add_io_instruction_handler(
 // Monitor Trap
 //--------------------------------------------------------------------------
 
-gsl::not_null<monitor_trap *> vcpu::monitor_trap()
+gsl::not_null<monitor_trap *> hve::monitor_trap()
 { return m_monitor_trap.get(); }
 
-void vcpu::add_monitor_trap_handler(monitor_trap::handler_delegate_t &&d)
+void hve::add_monitor_trap_handler(monitor_trap::handler_delegate_t &&d)
 {
     check_monitor_trap();
     m_monitor_trap->add_handler(std::move(d));
 }
 
-void vcpu::enable_monitor_trap_flag()
+void hve::enable_monitor_trap_flag()
 {
     check_monitor_trap();
     m_monitor_trap->enable();
@@ -166,10 +177,10 @@ void vcpu::enable_monitor_trap_flag()
 // Move DR
 //--------------------------------------------------------------------------
 
-gsl::not_null<mov_dr *> vcpu::mov_dr()
+gsl::not_null<mov_dr *> hve::mov_dr()
 { return m_mov_dr.get(); }
 
-void vcpu::add_mov_dr_handler(mov_dr::handler_delegate_t &&d)
+void hve::add_mov_dr_handler(mov_dr::handler_delegate_t &&d)
 {
     if (!m_mov_dr) {
         m_mov_dr = std::make_unique<eapis::intel_x64::mov_dr>(this);
@@ -182,13 +193,13 @@ void vcpu::add_mov_dr_handler(mov_dr::handler_delegate_t &&d)
 // Read MSR
 //--------------------------------------------------------------------------
 
-gsl::not_null<rdmsr *> vcpu::rdmsr()
+gsl::not_null<rdmsr *> hve::rdmsr()
 { return m_rdmsr.get(); }
 
-void vcpu::pass_through_all_rdmsr_accesses()
+void hve::pass_through_all_rdmsr_accesses()
 { check_rdmsr(); }
 
-void vcpu::add_rdmsr_handler(
+void hve::add_rdmsr_handler(
     vmcs_n::value_type msr, rdmsr::handler_delegate_t &&d)
 {
     check_rdmsr();
@@ -199,10 +210,10 @@ void vcpu::add_rdmsr_handler(
 // VPID
 //--------------------------------------------------------------------------
 
-gsl::not_null<vpid *> vcpu::vpid()
+gsl::not_null<vpid *> hve::vpid()
 { return m_vpid.get(); }
 
-void vcpu::enable_vpid()
+void hve::enable_vpid()
 {
     if (!m_vpid) {
         m_vpid = std::make_unique<eapis::intel_x64::vpid>();
@@ -213,13 +224,13 @@ void vcpu::enable_vpid()
 // Write MSR
 //--------------------------------------------------------------------------
 
-gsl::not_null<wrmsr *> vcpu::wrmsr()
+gsl::not_null<wrmsr *> hve::wrmsr()
 { return m_wrmsr.get(); }
 
-void vcpu::pass_through_all_wrmsr_accesses()
+void hve::pass_through_all_wrmsr_accesses()
 { check_wrmsr(); }
 
-void vcpu::add_wrmsr_handler(
+void hve::add_wrmsr_handler(
     vmcs_n::value_type msr, wrmsr::handler_delegate_t &&d)
 {
     check_wrmsr();
@@ -230,14 +241,14 @@ void vcpu::add_wrmsr_handler(
 // Checks
 //--------------------------------------------------------------------------
 
-void vcpu::check_crall()
+void hve::check_crall()
 {
     if (!m_control_register) {
         m_control_register = std::make_unique<eapis::intel_x64::control_register>(this);
     }
 }
 
-void vcpu::check_rdcr3()
+void hve::check_rdcr3()
 {
     check_crall();
 
@@ -247,7 +258,7 @@ void vcpu::check_rdcr3()
     }
 }
 
-void vcpu::check_wrcr3()
+void hve::check_wrcr3()
 {
     check_crall();
 
@@ -257,7 +268,7 @@ void vcpu::check_wrcr3()
     }
 }
 
-void vcpu::check_rdcr8()
+void hve::check_rdcr8()
 {
     check_crall();
 
@@ -267,7 +278,7 @@ void vcpu::check_rdcr8()
     }
 }
 
-void vcpu::check_wrcr8()
+void hve::check_wrcr8()
 {
     check_crall();
 
@@ -277,7 +288,7 @@ void vcpu::check_wrcr8()
     }
 }
 
-void vcpu::check_io_bitmaps()
+void hve::check_io_bitmaps()
 {
     using namespace vmcs_n;
 
@@ -291,14 +302,14 @@ void vcpu::check_io_bitmaps()
     }
 }
 
-void vcpu::check_monitor_trap()
+void hve::check_monitor_trap()
 {
     if (!m_monitor_trap) {
         m_monitor_trap = std::make_unique<eapis::intel_x64::monitor_trap>(this);
     }
 }
 
-void vcpu::check_msr_bitmap()
+void hve::check_msr_bitmap()
 {
     using namespace vmcs_n;
 
@@ -310,7 +321,7 @@ void vcpu::check_msr_bitmap()
     }
 }
 
-void vcpu::check_rdmsr()
+void hve::check_rdmsr()
 {
     check_msr_bitmap();
 
@@ -319,7 +330,7 @@ void vcpu::check_rdmsr()
     }
 }
 
-void vcpu::check_wrmsr()
+void hve::check_wrmsr()
 {
     check_msr_bitmap();
 
@@ -328,10 +339,10 @@ void vcpu::check_wrmsr()
     }
 }
 
-gsl::span<uint8_t> vcpu::msr_bitmap()
+gsl::span<uint8_t> hve::msr_bitmap()
 { return gsl::make_span(m_msr_bitmap.get(), ::x64::page_size); }
 
-gsl::span<uint8_t> vcpu::io_bitmaps()
+gsl::span<uint8_t> hve::io_bitmaps()
 { return gsl::make_span(m_io_bitmaps.get(), ::x64::page_size << 1U); }
 
 }

--- a/src/hve/arch/intel_x64/interrupt_window.cpp
+++ b/src/hve/arch/intel_x64/interrupt_window.cpp
@@ -1,0 +1,129 @@
+//
+// Bareflank Extended APIs
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <bfdebug.h>
+#include <hve/arch/intel_x64/hve.h>
+
+namespace eapis
+{
+namespace intel_x64
+{
+
+interrupt_window::interrupt_window(gsl::not_null<eapis::intel_x64::hve *> hve)
+{
+    using namespace vmcs_n;
+
+    hve->exit_handler()->add_handler(
+        exit_reason::basic_exit_reason::interrupt_window,
+        ::handler_delegate_t::create<interrupt_window, &interrupt_window::handle>(this)
+    );
+}
+
+void
+interrupt_window::add_handler(handler_delegate_t &&d)
+{ m_handlers.push_front(std::move(d)); }
+
+void
+interrupt_window::enable_exiting()
+{
+    using namespace vmcs_n;
+    primary_processor_based_vm_execution_controls::interrupt_window_exiting::enable();
+}
+
+void
+interrupt_window::disable_exiting()
+{
+    using namespace vmcs_n;
+    primary_processor_based_vm_execution_controls::interrupt_window_exiting::disable();
+}
+
+bool
+interrupt_window::is_open()
+{
+    using namespace vmcs_n;
+
+    if (guest_rflags::interrupt_enable_flag::is_disabled()) {
+        return false;
+    }
+
+    switch (guest_activity_state::get()) {
+        case guest_activity_state::active:
+        case guest_activity_state::hlt:
+            break;
+
+        case guest_activity_state::shutdown:
+        case guest_activity_state::wait_for_sipi:
+        default:
+            return false;
+    }
+
+    const auto state = guest_interruptibility_state::get();
+
+    if (guest_interruptibility_state::blocking_by_sti::is_enabled(state)) {
+        return false;
+    }
+
+    if (guest_interruptibility_state::blocking_by_mov_ss::is_enabled(state)) {
+        return false;
+    }
+
+    return true;
+}
+
+
+void
+interrupt_window::inject(uint64_t vector)
+{
+    using namespace vmcs_n::vm_entry_interruption_information;
+
+    auto info = 0U;
+    info = vector::set(info, vector);
+    info = interruption_type::set(info, interruption_type::external_interrupt);
+    info = valid_bit::enable(info);
+
+    vmcs_n::vm_entry_interruption_information::set(info);
+
+    return;
+}
+
+// -----------------------------------------------------------------------------
+// Debug
+// -----------------------------------------------------------------------------
+
+void
+interrupt_window::dump_log()
+{ }
+
+// -----------------------------------------------------------------------------
+// Handle
+// -----------------------------------------------------------------------------
+
+bool
+interrupt_window::handle(gsl::not_null<vmcs_t *> vmcs)
+{
+    for (const auto &d : m_handlers) {
+        if (d(vmcs)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+}
+}

--- a/src/hve/arch/intel_x64/io_instruction.cpp
+++ b/src/hve/arch/intel_x64/io_instruction.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfdebug.h>
-#include <hve/arch/intel_x64/vcpu.h>
+#include <hve/arch/intel_x64/hve.h>
 
 #include <bfvmm/memory_manager/arch/x64/map_ptr.h>
 
@@ -26,9 +26,9 @@ namespace eapis
 namespace intel_x64
 {
 
-io_instruction::io_instruction(gsl::not_null<eapis::intel_x64::vcpu *> vcpu) :
-    m_io_bitmaps{vcpu->io_bitmaps()},
-    m_exit_handler{vcpu->exit_handler()}
+io_instruction::io_instruction(gsl::not_null<eapis::intel_x64::hve *> hve) :
+    m_io_bitmaps{hve->io_bitmaps()},
+    m_exit_handler{hve->exit_handler()}
 {
     using namespace vmcs_n;
 

--- a/src/hve/arch/intel_x64/monitor_trap.cpp
+++ b/src/hve/arch/intel_x64/monitor_trap.cpp
@@ -17,15 +17,15 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfdebug.h>
-#include <hve/arch/intel_x64/vcpu.h>
+#include <hve/arch/intel_x64/hve.h>
 
 namespace eapis
 {
 namespace intel_x64
 {
 
-monitor_trap::monitor_trap(gsl::not_null<eapis::intel_x64::vcpu *> vcpu) :
-    m_exit_handler{vcpu->exit_handler()}
+monitor_trap::monitor_trap(gsl::not_null<eapis::intel_x64::hve *> hve) :
+    m_exit_handler{hve->exit_handler()}
 {
     using namespace vmcs_n;
 

--- a/src/hve/arch/intel_x64/mov_dr.cpp
+++ b/src/hve/arch/intel_x64/mov_dr.cpp
@@ -17,15 +17,15 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfdebug.h>
-#include <hve/arch/intel_x64/vcpu.h>
+#include <hve/arch/intel_x64/hve.h>
 
 namespace eapis
 {
 namespace intel_x64
 {
 
-mov_dr::mov_dr(gsl::not_null<eapis::intel_x64::vcpu *> vcpu) :
-    m_exit_handler{vcpu->exit_handler()}
+mov_dr::mov_dr(gsl::not_null<eapis::intel_x64::hve *> hve) :
+    m_exit_handler{hve->exit_handler()}
 {
     using namespace vmcs_n;
 

--- a/src/hve/arch/intel_x64/rdmsr.cpp
+++ b/src/hve/arch/intel_x64/rdmsr.cpp
@@ -17,16 +17,16 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfdebug.h>
-#include <hve/arch/intel_x64/vcpu.h>
+#include <hve/arch/intel_x64/hve.h>
 
 namespace eapis
 {
 namespace intel_x64
 {
 
-rdmsr::rdmsr(gsl::not_null<eapis::intel_x64::vcpu *> vcpu) :
-    m_msr_bitmap{vcpu->msr_bitmap()},
-    m_exit_handler{vcpu->exit_handler()}
+rdmsr::rdmsr(gsl::not_null<eapis::intel_x64::hve *> hve) :
+    m_msr_bitmap{hve->msr_bitmap()},
+    m_exit_handler{hve->exit_handler()}
 {
     using namespace vmcs_n;
 

--- a/src/hve/arch/intel_x64/wrmsr.cpp
+++ b/src/hve/arch/intel_x64/wrmsr.cpp
@@ -17,16 +17,16 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfdebug.h>
-#include <hve/arch/intel_x64/vcpu.h>
+#include <hve/arch/intel_x64/hve.h>
 
 namespace eapis
 {
 namespace intel_x64
 {
 
-wrmsr::wrmsr(gsl::not_null<eapis::intel_x64::vcpu *> vcpu) :
-    m_msr_bitmap{vcpu->msr_bitmap()},
-    m_exit_handler{vcpu->exit_handler()}
+wrmsr::wrmsr(gsl::not_null<eapis::intel_x64::hve *> hve) :
+    m_msr_bitmap{hve->msr_bitmap()},
+    m_exit_handler{hve->exit_handler()}
 {
     using namespace vmcs_n;
 

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -20,11 +20,14 @@ cmake_minimum_required(VERSION 3.6)
 project(eapis_main C CXX)
 
 include(${SOURCE_CMAKE_DIR}/project.cmake)
-init_project()
+init_project(
+    INCLUDES ${CMAKE_CURRENT_LIST_DIR}/../../include
+)
 
 if(${BUILD_TARGET_ARCH} STREQUAL "x86_64")
     list(APPEND SOURCES
         arch/intel_x64/vcpu_factory.cpp
+        ../vcpu/arch/intel_x64/vcpu.cpp
     )
 elseif(${BUILD_TARGET_ARCH} STREQUAL "aarch64")
     message(WARNING "Unimplemented")

--- a/src/vcpu/arch/intel_x64/vcpu.cpp
+++ b/src/vcpu/arch/intel_x64/vcpu.cpp
@@ -1,6 +1,5 @@
 //
 // Bareflank Extended APIs
-//
 // Copyright (C) 2018 Assured Information Security, Inc.
 //
 // This library is free software; you can redistribute it and/or
@@ -17,17 +16,26 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include <bfvmm/vcpu/vcpu_factory.h>
-#include <eapis/vcpu/arch/intel_x64/vcpu.h>
+#include <vcpu/arch/intel_x64/vcpu.h>
 
-namespace bfvmm
+namespace eapis
+{
+namespace intel_x64
 {
 
-std::unique_ptr<vcpu>
-vcpu_factory::make_vcpu(vcpuid::type vcpuid, bfobject *obj)
-{
-    bfignored(obj);
-    return std::make_unique<eapis::intel_x64::vcpu>(vcpuid);
+vcpu::vcpu(vcpuid::type id) :
+    bfvmm::intel_x64::vcpu{id},
+    m_hve{std::make_unique<eapis::intel_x64::hve>(exit_handler(), vmcs())}
+    //m_vic{std::make_unique<vic>(exit_handler(), vmcs())}
+{ }
+
+gsl::not_null<hve *>
+vcpu::hve()
+{ return m_hve.get(); }
+
+//gsl::not_null<vic *>
+//vcpu::vic()
+//{ return m_vic.get(); }
+
 }
-
 }


### PR DESCRIPTION
- Add an interrupt_window subclass of base used to register
  handlers for interrupt-window exits
- Add interrupt_window interface to vcpu

Signed-off-by: Connor Davis <davisc@ainfosec.com>