### PR TITLE
vic: Fix write cr8 bug

### DIFF
--- a/bfvmm/src/vic/arch/intel_x64/phys_x2apic.cpp
+++ b/bfvmm/src/vic/arch/intel_x64/phys_x2apic.cpp
@@ -58,7 +58,7 @@ phys_x2apic::read_version() const
 
 uint64_t
 phys_x2apic::read_tpr() const
-{ return ::intel_x64::msrs::ia32_x2apic_tpr::get(); }
+{ return ::intel_x64::cr8::get() << 4U; }
 
 uint64_t
 phys_x2apic::read_svr() const
@@ -74,7 +74,7 @@ phys_x2apic::write_eoi()
 
 void
 phys_x2apic::write_tpr(uint64_t tpr)
-{ ::intel_x64::msrs::ia32_x2apic_tpr::set(tpr); }
+{ ::intel_x64::cr8::set(tpr >> 4U); }
 
 void
 phys_x2apic::write_svr(uint64_t svr)

--- a/bfvmm/src/vic/arch/intel_x64/vic.cpp
+++ b/bfvmm/src/vic/arch/intel_x64/vic.cpp
@@ -405,6 +405,7 @@ vic::handle_wrcr8(
     bfignored(vmcs);
 
     m_virt_lapic->write_tpr(info.val << 4U);
+    m_phys_lapic->write_tpr(info.val << 4U);
 
     info.ignore_write = false;
     info.ignore_advance = false;


### PR DESCRIPTION
The base handler for cr8 writes does not do the write
for you. The vic's call to cr8 in ~vic was trapping,
but the hypervisor wasn't writing the physical value,
leaving the vmm susceptible to interrupt exits
in between interrupt handler destruction (i.e. in ~vic())
and guest promotion.

Write to physical cr8 in the vic's wrcr8 handler