### PR TITLE
Add linux driver for integration testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,17 @@ doxygen_warnings.txt
 ._.DS_Store
 tags
 *.swp
+
+bfdriver/src/linux/.bftest.ko.cmd
+bfdriver/src/linux/.bftest.mod.o.cmd
+bfdriver/src/linux/.bftest.o.cmd
+bfdriver/src/linux/.cache.mk
+bfdriver/src/linux/.entry.o.cmd
+bfdriver/src/linux/.tmp_versions/
+bfdriver/src/linux/Module.symvers
+bfdriver/src/linux/bftest.ko
+bfdriver/src/linux/bftest.mod.c
+bfdriver/src/linux/bftest.mod.o
+bfdriver/src/linux/bftest.o
+bfdriver/src/linux/entry.o
+bfdriver/src/linux/modules.order

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,17 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+# ------------------------------------------------------------------------------
+# Includes
+# ------------------------------------------------------------------------------
+
+include(${CMAKE_CURRENT_LIST_DIR}/scripts/cmake/macros.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/scripts/cmake/targets.cmake)
+
+# ------------------------------------------------------------------------------
+# Extensions
+# ------------------------------------------------------------------------------
+
 if(ENABLE_BUILD_VMM)
     vmm_extension(
         eapis
@@ -28,60 +39,15 @@ if(ENABLE_BUILD_VMM)
         SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bfvmm/src/main
     )
 
-# MOVE ME
+    if(ENABLE_BUILD_INTEGRATION)
+        add_integration(control_register)
+        add_integration(cpuid)
+        add_integration(io_instruction)
+        add_integration(monitor_trap)
+        add_integration(mov_dr)
+        add_integration(rdmsr)
+        add_integration(vpid)
+        add_integration(wrmsr)
+    endif()
 
-    vmm_extension(
-        eapis_integration_intel_x64_control_register
-        DEPENDS eapis
-        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bfvmm/integration/arch/intel_x64/control_register/
-    )
-
-    vmm_extension(
-        eapis_integration_intel_x64_cpuid
-        DEPENDS eapis
-        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bfvmm/integration/arch/intel_x64/cpuid/
-    )
-
-    vmm_extension(
-        eapis_integration_intel_x64_io_instruction
-        DEPENDS eapis
-        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bfvmm/integration/arch/intel_x64/io_instruction/
-    )
-
-    vmm_extension(
-        eapis_integration_intel_x64_monitor_trap
-        DEPENDS eapis
-        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bfvmm/integration/arch/intel_x64/monitor_trap/
-    )
-
-    vmm_extension(
-        eapis_integration_intel_x64_mov_dr
-        DEPENDS eapis
-        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bfvmm/integration/arch/intel_x64/mov_dr/
-    )
-
-    vmm_extension(
-        eapis_integration_intel_x64_rdmsr
-        DEPENDS eapis
-        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bfvmm/integration/arch/intel_x64/rdmsr/
-    )
-
-    vmm_extension(
-        eapis_integration_intel_x64_vpid
-        DEPENDS eapis
-        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bfvmm/integration/arch/intel_x64/vpid/
-    )
-
-    vmm_extension(
-        eapis_integration_intel_x64_wrmsr
-        DEPENDS eapis
-        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bfvmm/integration/arch/intel_x64/wrmsr/
-    )
 endif()
-
-# if(ENABLE_BUILD_TEST)
-#     test_extension(
-#         eapis
-#         SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/tests
-#     )
-# endif()

--- a/bfdriver/src/linux/Makefile
+++ b/bfdriver/src/linux/Makefile
@@ -1,0 +1,46 @@
+#
+# Bareflank Hypervisor
+# Copyright (C) 2018 Assured Information Security, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+TARGET_MODULE:=bftest
+
+ifneq ($(KERNELRELEASE),)
+	obj-m := $(TARGET_MODULE).o
+
+	$(TARGET_MODULE)-objs += entry.o
+
+	EXTRA_CFLAGS += -DKERNEL
+	EXTRA_CFLAGS += -DLINUX_KERNEL
+	EXTRA_CFLAGS += -I$(src)/../../../../hypervisor/bfsdk/include/
+else
+	BUILDSYSTEM_DIR:=/lib/modules/$(shell uname -r)/build
+	PWD:=$(shell pwd)
+
+all:
+	$(MAKE) -C $(BUILDSYSTEM_DIR) M=$(PWD) modules
+
+clean:
+	$(MAKE) -C $(BUILDSYSTEM_DIR) M=$(PWD) clean
+	rm -f entry.o
+
+load:
+	insmod ./$(TARGET_MODULE).ko
+
+unload:
+	-rmmod ./$(TARGET_MODULE).ko
+
+endif

--- a/bfdriver/src/linux/entry.c
+++ b/bfdriver/src/linux/entry.c
@@ -1,0 +1,76 @@
+/*
+ * Bareflank Hypervisor
+ * Copyright (C) 2018 Assured Information Security, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <linux/module.h>
+
+#include <bfdebug.h>
+#include <bftypes.h>
+#include <bfconstants.h>
+
+/* -------------------------------------------------------------------------- */
+/* Minimal vmcall interface                                                   */
+/* -------------------------------------------------------------------------- */
+
+struct vmcall_args {
+    uintptr_t rax;
+    uintptr_t rdx;
+    uintptr_t rcx;
+    uintptr_t rbx;
+};
+
+static inline void
+vmcall(struct vmcall_args *arg)
+{
+    asm volatile(
+        "movq %4, %%rax \n\t"
+        "movq %5, %%rbx \n\t"
+        "movq %6, %%rcx \n\t"
+        "movq %7, %%rdx \n\t"
+        "vmcall         \n\t"
+        "movq %%rax, %0 \n\t"
+        "movq %%rbx, %1 \n\t"
+        "movq %%rcx, %2 \n\t"
+        "movq %%rdx, %3 \n\t"
+        : "=m"(arg[0]), "=m"(arg[1]), "=m"(arg[2]), "=m"(arg[3])
+        : "a"(arg[0]), "b"(arg[1]), "c"(arg[2]), "d"(arg[3])
+    );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Entry / Exit                                                               */
+/* -------------------------------------------------------------------------- */
+
+int
+bftest_init(void)
+{
+    BFDEBUG("bftest_init succeeded\n");
+    return 0;
+}
+
+void
+bftest_exit(void)
+{
+    BFDEBUG("bftest_exit succeeded\n");
+    return;
+}
+
+module_init(bftest_init);
+module_exit(bftest_exit);
+
+MODULE_LICENSE("GPL");

--- a/scripts/cmake/macros.cmake
+++ b/scripts/cmake/macros.cmake
@@ -1,0 +1,31 @@
+#
+# Bareflank Hypervisor
+# Copyright (C) 2018 Assured Information Security, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+function(add_integration INTEGRATION_DIR)
+    set(TEST_SRC ${CMAKE_CURRENT_LIST_DIR}/bfvmm/integration/arch/intel_x64/${INTEGRATION_DIR})
+
+    if(NOT EXISTS "${TEST_SRC}")
+        message(FATAL_ERROR "add_integration path not found: ${TEST_SRC}")
+    endif()
+
+    vmm_extension(
+        eapis_integration_intel_x64_${INTEGRATION_DIR}
+        DEPENDS eapis
+        SOURCE_DIR ${TEST_SRC}
+    )
+endfunction(add_integration)

--- a/scripts/cmake/targets.cmake
+++ b/scripts/cmake/targets.cmake
@@ -1,0 +1,83 @@
+#
+# Bareflank Hypervisor
+# Copyright (C) 2018 Assured Information Security, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+if(NOT WIN32 AND NOT CYGWIN)
+    set(SUDO sudo)
+else()
+    set(SUDO "")
+endif()
+
+# ------------------------------------------------------------------------------
+# Integration Driver
+# ------------------------------------------------------------------------------
+
+if(NOT WIN32 AND ENABLE_BUILD_INTEGRATION)
+    add_custom_target_category("Bareflank Test Driver")
+
+    set(SOURCE_UTIL_DIR ${CMAKE_CURRENT_LIST_DIR}/../util)
+    set(SOURCE_BFDRIVER_DIR ${CMAKE_CURRENT_LIST_DIR}/../../bfdriver)
+
+    add_custom_target(bftest_build
+        COMMAND ${SOURCE_UTIL_DIR}/driver_build.sh ${SOURCE_BFDRIVER_DIR}
+        USES_TERMINAL
+    )
+    add_custom_target_info(
+        TARGET bftest_build
+        COMMENT "Build the Bareflank test driver"
+    )
+
+    add_custom_target(bftest_clean
+        COMMAND ${SOURCE_UTIL_DIR}/driver_clean.sh ${SOURCE_BFDRIVER_DIR}
+        USES_TERMINAL
+    )
+    add_custom_target_info(
+        TARGET bftest_clean
+        COMMENT "Clean the Bareflank test driver"
+    )
+
+    add_custom_target(bftest_load
+        COMMAND ${SOURCE_UTIL_DIR}/driver_load.sh ${SOURCE_BFDRIVER_DIR}
+        USES_TERMINAL
+    )
+    add_custom_target_info(
+        TARGET bftest_load
+        COMMENT "Load the Bareflank test driver"
+    )
+
+    add_custom_target(bftest_unload
+        COMMAND ${SOURCE_UTIL_DIR}/driver_unload.sh ${SOURCE_BFDRIVER_DIR}
+        USES_TERMINAL
+    )
+    add_custom_target_info(
+        TARGET bftest_unload
+        COMMENT "Unload the Bareflank test driver"
+    )
+
+    add_custom_target(
+        bftest_quick
+        COMMAND ${CMAKE_COMMAND} --build . --target bftest_unload
+        COMMAND ${CMAKE_COMMAND} --build . --target bftest_clean
+        COMMAND ${CMAKE_COMMAND} --build . --target bftest_build
+        COMMAND ${CMAKE_COMMAND} --build . --target bftest_load
+        USES_TERMINAL
+    )
+    add_custom_target_info(
+        TARGET bftest_quick
+        COMMENT "Unload, clean, build, and load the Bareflank test driver"
+    )
+endif()

--- a/scripts/util/driver_build.sh
+++ b/scripts/util/driver_build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -e
+#
+# Bareflank Hypervisor
+# Copyright (C) 2018 Assured Information Security, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+# $1 == CMAKE_SOURCE_DIR
+
+case $(uname -s) in
+Linux)
+    cd $1/src/linux
+    make
+    ;;
+*)
+    >&2 echo "OS not supported"
+    exit 1
+esac

--- a/scripts/util/driver_clean.sh
+++ b/scripts/util/driver_clean.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+#
+# Bareflank Hypervisor
+# Copyright (C) 2018 Assured Information Security, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+case $(uname -s) in
+Linux)
+    cd $1/src/linux
+    make clean
+    ;;
+*)
+    >&2 echo "OS not supported"
+    exit 1
+esac

--- a/scripts/util/driver_load.sh
+++ b/scripts/util/driver_load.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -e
+#
+# Bareflank Hypervisor
+# Copyright (C) 2018 Assured Information Security, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+# $1 == CMAKE_SOURCE_DIR
+
+case $(uname -s) in
+Linux)
+    cd $1/src/linux
+    sudo make unload 1> /dev/null 2> /dev/null
+    sudo make load 1> /dev/null 2> /dev/null
+    ;;
+*)
+    >&2 echo "OS not supported"
+    exit 1
+esac

--- a/scripts/util/driver_unload.sh
+++ b/scripts/util/driver_unload.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+#
+# Bareflank Hypervisor
+# Copyright (C) 2018 Assured Information Security, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+case $(uname -s) in
+Linux)
+    cd $1/src/linux
+    sudo make unload 1> /dev/null 2> /dev/null
+    ;;
+*)
+    >&2 echo "OS not supported"
+    exit 1
+esac


### PR DESCRIPTION
Some integration tests will need access to resources managed by the
kernel in order to work effectively e.g. the interrupt test needs to get
a list of free vectors it may inject during testing.

- Add an initial, minimal driver under bfdriver
- Add scripts for building and running the driver
- Add the ENABLE_BUILD_INTEGRATION cmake option, along with a macro
  for creating integration test targets