### PR TITLE
Install EAPI headers into the test prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,9 +79,9 @@ if(ENABLE_BUILD_VMM)
     )
 endif()
 
-# if(ENABLE_BUILD_TEST)
-#     test_extension(
-#         eapis
-#         SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/tests
-#     )
-# endif()
+if(ENABLE_BUILD_TEST)
+    test_extension(
+        eapis
+        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bfvmm/tests/
+    )
+endif()

--- a/bfvmm/tests/CMakeLists.txt
+++ b/bfvmm/tests/CMakeLists.txt
@@ -1,0 +1,31 @@
+##
+## Bareflank Hypervisor
+## Copyright (C) 2018 Assured Information Security, Inc.
+##
+## This library is free software; you can redistribute it and/or
+## modify it under the terms of the GNU Lesser General Public
+## License as published by the Free Software Foundation; either
+## version 2.1 of the License, or (at your option) any later version.
+##
+## This library is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public
+## License along with this library; if not, write to the Free Software
+## Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+cmake_minimum_required(VERSION 3.6)
+project(eapis_test C CXX)
+
+include(${SOURCE_CMAKE_DIR}/project.cmake)
+init_project(
+    INCLUDES ${CMAKE_CURRENT_LIST_DIR}/../include
+)
+
+# -----------------------------------------------------------------------------
+# Install
+# -----------------------------------------------------------------------------
+
+install(DIRECTORY ../include/ DESTINATION include/eapis)


### PR DESCRIPTION
Currently, there are no unit tests for EAPIs so none of the EAPI headers are being installed in the test prefix. This quick patch enables an empty test extension that just installs the headers correctly. This allows extensions to reference EAPI headers in their tests and provides a structure for future EAPI tests.