### PR TITLE
BUG - Bad PML4 entry rwx defaults

### DIFF
--- a/bfvmm/src/hve/arch/intel_x64/ept/memory_map.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/ept/memory_map.cpp
@@ -273,6 +273,7 @@ memory_map::map_pdpte_to_page(gpa_t gpa, hpa_t hpa)
 
         epte::read_access::enable(pml4e);
         epte::write_access::enable(pml4e);
+        epte::execute_access::enable(pml4e);
         epte::set_hpa(pml4e, pdpt_hpa);
     }
 
@@ -296,6 +297,7 @@ memory_map::map_pde_to_page(gpa_t gpa, hpa_t hpa)
 
         epte::read_access::enable(pml4e);
         epte::write_access::enable(pml4e);
+        epte::execute_access::enable(pml4e);
         epte::set_hpa(pml4e, pdpt_hpa);
     }
 
@@ -328,6 +330,7 @@ memory_map::map_pte_to_page(gpa_t gpa, hpa_t hpa)
 
         epte::read_access::enable(pml4e);
         epte::write_access::enable(pml4e);
+        epte::execute_access::enable(pml4e);
         epte::set_hpa(pml4e, pdpt_hpa);
     }
 


### PR DESCRIPTION
The current default read-write-execute values for EPT PML4 entries created by
the memory_map prohibits users of the memory map API from marking any pages as
executable. This is happening because the memory_map implementaiton is marking
all PML4 entries as non-executable by default. Since the memory
map API only allows the user to manipulate leaf page table entries,
there is no way to mark a page executable when a parent (PML4) EPT entry has
its execute bit set to 0.

This commit changes the default read-write-execute values for all EPT
PML4 entries created via the memory_map from rw to rwe. "Leaf" entries
still default to rw.

Signed-off-by JaredWright <jared.wright12@gmail.com>