### PR TITLE
Qualify types to avoid compile error

### DIFF
--- a/bfvmm/include/hve/arch/intel_x64/hve.h
+++ b/bfvmm/include/hve/arch/intel_x64/hve.h
@@ -451,7 +451,7 @@ public:
     /// @return Returns the EPT misconfiguration object stored in the hve if EPT
     ///     trapping is enabled, otherwise an exception is thrown
     ///
-    gsl::not_null<ept_misconfiguration *> ept_misconfiguration();
+    gsl::not_null<eapis::intel_x64::ept_misconfiguration *> ept_misconfiguration();
 
     /// Add EPT Misconfiguration Handler
     ///
@@ -473,7 +473,7 @@ public:
     /// @return Returns the EPT violation object stored in the hve if EPT
     ///     trapping is enabled, otherwise an exception is thrown
     ///
-    gsl::not_null<ept_violation *> ept_violation();
+    gsl::not_null<eapis::intel_x64::ept_violation *> ept_violation();
 
     /// Add EPT read violation handler
     ///

--- a/bfvmm/src/hve/arch/intel_x64/hve.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/hve.cpp
@@ -258,7 +258,7 @@ void hve::add_wrmsr_handler(
 // EPT Misconfiguration
 //--------------------------------------------------------------------------
 
-gsl::not_null<ept_misconfiguration *> hve::ept_misconfiguration()
+gsl::not_null<eapis::intel_x64::ept_misconfiguration *> hve::ept_misconfiguration()
 { return m_ept_misconfiguration.get(); }
 
 void hve::add_ept_misconfiguration_handler(
@@ -275,7 +275,7 @@ void hve::add_ept_misconfiguration_handler(
 // EPT Violation
 //--------------------------------------------------------------------------
 
-gsl::not_null<ept_violation *> hve::ept_violation()
+gsl::not_null<eapis::intel_x64::ept_violation *> hve::ept_violation()
 { return m_ept_violation.get(); }
 
 void hve::add_ept_read_violation_handler(


### PR DESCRIPTION
Add `eapis::intel_x64::` qualifier to method return types to fix compile error on clang 6.0.0