### PR TITLE
Add eapis::phys_pci for access to physical PCI devices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,12 @@ if(ENABLE_BUILD_VMM)
         DEPENDS eapis
         SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bfvmm/integration/arch/intel_x64/wrmsr/
     )
+
+    vmm_extension(
+        eapis_integration_intel_x64_phys_pci
+        DEPENDS eapis
+        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bfvmm/integration/arch/intel_x64/phys_pci/
+    )
 endif()
 
 if(ENABLE_BUILD_TEST)

--- a/bfvmm/include/hve/pci_register.h
+++ b/bfvmm/include/hve/pci_register.h
@@ -1,0 +1,136 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef PCI_REGISTER_H
+#define PCI_REGISTER_H
+
+namespace eapis
+{
+
+/// PCI configuration access
+namespace pci
+{
+
+/// Type of geographic bus index
+using bus_type = uint8_t;
+
+/// Type of geographic device index. Should be <= 31
+using device_type = uint8_t;
+
+/// Type of geographic function index. Should be <= 7
+using func_type = uint8_t;
+
+/// Type of register index. Should be <= 0x3F
+using register_type = uint8_t;
+
+///
+/// @brief Read 8 bits from a geographically addressed register.
+///
+/// @expects bus <= 255, device <= 31, func <= 7, reg <= 0x3F
+/// @ensures
+///
+/// @param bus PCI bus number
+/// @param device Device number on the bus
+/// @param func Function, for multifunction devices (or 0)
+/// @param reg register index in bytes
+///
+/// @return contents of the register, or 0xFF for nonexistent devices
+///
+uint8_t
+read_register_u8(bus_type bus, device_type device, func_type func, register_type reg);
+
+///
+/// @brief Read 16 bits from a geographically addressed register.
+///
+/// @expects bus <= 255, device <= 31, func <= 7, reg <= 0x3F, reg is 16-bit aligned
+/// @ensures
+///
+/// @param bus PCI bus number
+/// @param device Device number on the bus
+/// @param func Function, for multifunction devices (or 0)
+/// @param reg register index in bytes
+///
+/// @return contents of the register, or 0xFFFF for nonexistent devices
+///
+uint16_t
+read_register_u16(bus_type bus, device_type device, func_type func, register_type reg);
+
+///
+/// @brief Read 32 bits from a geographically addressed register.
+///
+/// @expects bus <= 255, device <= 31, func <= 7, reg <= 0x3F, reg is 32-bit aligned
+/// @ensures
+///
+/// @param bus PCI bus number
+/// @param device Device number on the bus
+/// @param func Function, for multifunction devices (or 0)
+/// @param reg register index in bytes
+///
+/// @return contents of the register, or 0xFFFFFFFF for nonexistent devices
+///
+uint32_t
+read_register_u32(bus_type bus, device_type device, func_type func, register_type reg);
+
+///
+/// @brief Write 32 bits to a geographically addressed register.
+///
+/// @expects bus <= 255, device <= 31, func <= 7, reg <= 0x3F, reg is 32-bit aligned
+/// @ensures
+///
+/// @param bus PCI bus number
+/// @param device Device number on the bus
+/// @param func Function, for multifunction devices (or 0)
+/// @param reg register index in bytes
+/// @param value value to write
+///
+void
+write_register(bus_type bus, device_type device, func_type func, register_type reg, uint32_t value);
+
+///
+/// @brief Perform an 8-bit read-modify-write operation on a geographically addressed 32-bit register.
+///
+/// @expects bus <= 255, device <= 31, func <= 7, reg <= 0x3F
+/// @ensures
+///
+/// @param bus PCI bus number
+/// @param device Device number on the bus
+/// @param func Function, for multifunction devices (or 0)
+/// @param reg register index in bytes
+/// @param value value to write
+///
+void rmw_register_u8(bus_type bus, device_type device, func_type func, register_type reg, uint8_t value);
+
+///
+/// @brief Perform a 16-bit read-modify-write operation on a geographically addressed 32-bit register.
+///
+/// @expects bus <= 255, device <= 31, func <= 7, reg <= 0x3F, reg is 16-bit aligned
+/// @ensures
+///
+/// @param bus PCI bus number
+/// @param device Device number on the bus
+/// @param func Function, for multifunction devices (or 0)
+/// @param reg register index in bytes
+/// @param value value to write
+///
+void rmw_register_u16(bus_type bus, device_type device, func_type func, register_type reg, uint16_t value);
+
+}
+
+}
+
+#endif

--- a/bfvmm/include/hve/phys_pci.h
+++ b/bfvmm/include/hve/phys_pci.h
@@ -1,0 +1,351 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef PHYS_PCI_EAPIS_H
+#define PHYS_PCI_EAPIS_H
+
+#include <bfexports.h>
+#include <vector>
+#include "pci_register.h"
+
+#ifndef STATIC_HVE
+#ifdef SHARED_HVE
+#define EXPORT_HVE EXPORT_SYM
+#else
+#define EXPORT_HVE IMPORT_SYM
+#endif
+#else
+#define EXPORT_HVE
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif
+
+namespace eapis
+{
+namespace pci
+{
+
+/// Physical PCI device
+///
+/// This class provides register-level access to a physical PCI
+/// device.
+class EXPORT_HVE phys_pci
+{
+public:
+    ///
+    /// Construct a phys_pci device for a given geographical address. The device
+    /// is not required to exist; you can check for the existence of a device by
+    /// instantiating it and then checking whether the vendor and device IDs are
+    /// 0xFFFF.
+    ///
+    /// @expects bus <= 255, device <= 31, func <= 7
+    /// @ensures
+    ///
+    /// @param bus PCI bus number
+    /// @param device Device number on the bus
+    /// @param func Function, for multifunction devices (or 0)
+    ///
+    phys_pci(bus_type bus, device_type device, func_type func)
+        : m_bus(bus),
+          m_device(device),
+          m_func(func)
+    {}
+
+    virtual ~phys_pci() = default;
+
+    /// @brief Get the geographical PCI bus number of this device.
+    /// @return Geographical bus number
+    inline bus_type bus() const { return m_bus; }
+
+    /// @brief Get the geographical device number of this device.
+    /// @return Geographical device number
+    inline device_type device() const { return m_device; }
+
+    /// @brief Get the function number of this device.
+    /// @return Geographical function number
+    inline func_type func() const { return m_func; }
+
+    ///
+    /// Enumerate all the PCI devices on this system into a vector. This will
+    /// recursively enumerate all bridges.
+    ///
+    /// @expects
+    /// @ensures All devices returned in `vect` exist.
+    ///
+    /// @param vect a vector to collect devices.
+    ///
+    static void enumerate(std::vector<phys_pci> &vect);
+
+    /// @brief Get the device (product) ID, or 0xFFFF if the device doesn't exist
+    /// @return the device (product) ID, or 0xFFFF if the device doesn't exist
+    inline uint16_t device_id() const { return read_register_u16(0x02); }
+
+    /// @brief Get the vendor ID, or 0xFFFF if the device doesn't exist.
+    /// @return the vendor ID, or 0xFFFF if the device doesn't exist.
+    inline uint16_t vendor_id() const { return read_register_u16(0x00); }
+
+    /// @brief Get the status code
+    /// @return the status code
+    inline uint16_t status() const { return read_register_u16(0x06); }
+
+    /// @brief Get the contents of the command register
+    /// @return the contents of the command register
+    inline uint16_t read_command() const { return read_register_u16(0x04); }
+
+    /// @brief Get the device's class
+    /// @return the device's class
+    inline uint8_t device_class() const { return read_register_u8(0x0B); }
+
+    /// @brief Get the device's subclass
+    /// @return the device's subclass
+    inline uint8_t device_subclass() const { return read_register_u8(0x0A); }
+
+    /// @brief Get the device's programming interface
+    /// @return the device's programming interface
+    inline uint8_t prog_if() const { return read_register_u8(0x09); }
+
+    /// @brief Get the device's revision ID
+    /// @return the device's revision ID
+    inline uint8_t revision() const { return read_register_u8(0x08); }
+
+    /// @brief Get the built-in self test control register
+    /// @return the built-in self test control register
+    inline uint8_t read_bist() const { return read_register_u8(0x0F); }
+
+    ///
+    /// @brief Return the PCI descriptor type.
+    ///
+    /// The high bit (0x80) indicates whether this is a multifunction device. If
+    /// the low seven bits are not 0x00, other register read methods may be
+    /// invalid as phys_pci is only implemented for type 0 devices; type 1 and
+    /// type 2 devices must be read using the read_register methods directly.
+    ///
+    /// @return the PCI descriptor type.
+    ///
+    inline uint8_t header_type() const { return read_register_u8(0x0E); }
+
+    /// @brief Get the device's bus latency
+    /// @return the device's bus latency
+    inline uint8_t latency() const { return read_register_u8(0x0D); }
+
+    /// @brief Get the system cache line size in 32-bit dwords
+    /// @return the system cache line size in 32-bit dwords
+    inline uint8_t cl_size() const { return read_register_u8(0x0C); }
+
+    /// @brief Get the Cardbus CIS pointer
+    /// @return the Cardbus CIS pointer
+    inline uint32_t cisp() const { return read_register_u32(0x28); }
+
+    /// @brief Get the subsystem ID
+    /// @return the subsystem ID
+    inline uint16_t subsystem_id() const { return read_register_u16(0x2E); }
+
+    /// @brief Get the subsystem vendor ID
+    /// @return the subsystem vendor ID
+    inline uint16_t subsystem_vid() const { return read_register_u16(0x2C); }
+
+    /// @brief Get the expansion ROM base address register
+    /// @return the expansion ROM base address register
+    inline uint32_t exprom_bar() const { return read_register_u32(0x30); }
+
+    /// @brief Get the pointer to the capabilities list, if (status() & 0x10) != 0.
+    /// @return the pointer to the capabilities list, if (status() & 0x10) != 0.
+    inline uint8_t capabilities_ptr() const { return read_register_u8(0x34); }
+
+    /// @brief Get the device's maximum bus latency in 0.25us units
+    /// @return the device's maximum bus latency in 0.25us units
+    inline uint8_t max_latency() const { return read_register_u8(0x3F); }
+
+    /// @brief Get the device's required burst period in 0.25us units
+    /// @return the device's required burst period in 0.25us units
+    inline uint8_t min_grant() const { return read_register_u8(0x3E); }
+
+    /// @brief Get the device's interrupt pin
+    /// @return the device's interrupt pin
+    inline uint8_t int_pin() const { return read_register_u8(0x3D); }
+
+    /// @brief Get the device's interrupt line
+    /// @return the device's interrupt line
+    inline uint8_t int_line() const { return read_register_u8(0x3C); }
+
+    ///
+    /// @brief Return the contents of the specified base address register.
+    ///
+    /// @expects n < 6
+    /// @ensures invalid indices return 0xFFFFFFFF
+    ///
+    /// @param n index of the desired base address register
+    ///
+    /// @return contents of the specified base address register, or 0xFFFFFFFF for invalid indices
+    ///
+    inline uint32_t bar(uint8_t n) const
+    {
+        if (n < 6) {
+            return read_register_u32(0x10 + 4 * n);
+        } else {
+            return 0xFFFFFFFF;
+        }
+    }
+
+    /// Write a command to the device's command register
+    /// @param command command register contents
+    inline void send_command(uint16_t command) { rmw_register_u16(0x04, command); }
+
+    /// Write a built-in self test command to the device's BIST register
+    /// @param value BIST register contents
+    inline void send_bist(uint8_t value) { rmw_register_u8(0x0F, value); }
+
+    /// Set the device's bus latency in PCI bus clocks
+    /// @param cycles bus latency in PCI bus clocks
+    inline void set_latency(uint8_t cycles) { rmw_register_u8(0x0D, cycles); }
+
+    /// Set the system cache line size in 32-bit dwords
+    /// @param n_dwords cache line size in 32-bit dwords
+    inline void set_cl_size(uint8_t n_dwords) { rmw_register_u8(0x0C, n_dwords); }
+
+    /// Set the expansion ROM base address register
+    /// @param value expansion ROM base address register contents
+    inline void set_exprom_bar(uint32_t value) { write_register(0x30, value); }
+
+    /// Set the device's interrupt line
+    /// @param line interrupt line
+    inline void set_int_line(uint8_t line) { rmw_register_u8(0x3C, line); }
+
+    ///
+    /// @brief Set the contents of the specified base address register.
+    ///
+    /// @expects n < 6
+    /// @ensures invalid indices cause no write
+    ///
+    /// @param n index of the desired base address register
+    /// @param value value to write
+    ///
+    inline void set_bar(uint8_t n, uint32_t value)
+    {
+        if (n < 6) {
+            write_register(0x10 + 4 * n, value);
+        }
+    }
+
+    ///
+    /// @brief Read 8 bits from a register.
+    ///
+    /// @expects reg <= 0x3F
+    /// @ensures
+    ///
+    /// @param reg register index in bytes
+    ///
+    /// @return contents of the register
+    ///
+    inline uint8_t read_register_u8(register_type reg) const
+    {
+        return pci::read_register_u8(m_bus, m_device, m_func, reg);
+    }
+
+    ///
+    /// @brief Read 16 bits from a register.
+    ///
+    /// @expects reg <= 0x3F and reg is 16-bit aligned
+    /// @ensures
+    ///
+    /// @param reg register index in bytes
+    ///
+    /// @return contents of the register
+    ///
+    inline uint16_t read_register_u16(register_type reg) const
+    {
+        return pci::read_register_u16(m_bus, m_device, m_func, reg);
+    }
+
+    ///
+    /// @brief Read 32 bits from a register.
+    ///
+    /// @expects reg <= 0x3F and reg is 32-bit aligned
+    /// @ensures
+    ///
+    /// @param reg register index in bytes
+    ///
+    /// @return contents of the register
+    ///
+    inline uint32_t read_register_u32(register_type reg) const
+    {
+        return pci::read_register_u32(m_bus, m_device, m_func, reg);
+    }
+
+    ///
+    /// @brief Write 32 bits to a register.
+    ///
+    /// @expects reg <= 0x3F and reg is 32-bit aligned
+    /// @ensures
+    ///
+    /// @param reg register index in bytes
+    /// @param val value to write
+    ///
+    void write_register(register_type reg, uint32_t val)
+    {
+        pci::write_register(m_bus, m_device, m_func, reg, val);
+    }
+
+    ///
+    /// @brief Perform an 8-bit read-modify-write operation on a 32-bit register.
+    ///
+    /// @expects reg <= 0x3F
+    /// @ensures
+    ///
+    /// @param reg register index in bytes
+    /// @param val value to write
+    ///
+    void rmw_register_u8(register_type reg, uint8_t val)
+    {
+        pci::rmw_register_u8(m_bus, m_device, m_func, reg, val);
+    }
+
+    ///
+    /// @brief Perform a 16-bit read-modify-write operation on a 32-bit register.
+    ///
+    /// @expects reg <= 0x3F and reg is 16-bit aligned
+    /// @ensures
+    ///
+    /// @param reg register index in bytes
+    /// @param val value to write
+    ///
+    void rmw_register_u16(register_type reg, uint16_t val)
+    {
+        pci::rmw_register_u16(m_bus, m_device, m_func, reg, val);
+    }
+
+protected:
+
+    /// Geographical bus number
+    bus_type m_bus;
+
+    /// Geographical device number
+    device_type m_device;
+
+    /// Geographical function number
+    func_type m_func;
+
+};
+
+}
+}
+
+#endif

--- a/bfvmm/integration/arch/intel_x64/phys_pci/CMakeLists.txt
+++ b/bfvmm/integration/arch/intel_x64/phys_pci/CMakeLists.txt
@@ -1,0 +1,31 @@
+#
+# Bareflank Hypervisor
+# Copyright (C) 2018 Assured Information Security, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+cmake_minimum_required(VERSION 3.6)
+project(eapis_main C CXX)
+
+include(${SOURCE_CMAKE_DIR}/project.cmake)
+init_project(
+    INCLUDES ../../../../include
+)
+
+add_vmm_executable(
+    eapis_integration_intel_x64_phys_pci
+    SOURCES phys_pci.cpp
+    LIBRARIES eapis_hve
+)

--- a/bfvmm/integration/arch/intel_x64/phys_pci/phys_pci.cpp
+++ b/bfvmm/integration/arch/intel_x64/phys_pci/phys_pci.cpp
@@ -1,0 +1,85 @@
+//
+// Bareflank Extended APIs
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <bfvmm/vcpu/vcpu_factory.h>
+#include <eapis/vcpu/arch/intel_x64/vcpu.h>
+#include <eapis/hve/phys_pci.h>
+#include <vector>
+
+using namespace eapis;
+
+// -----------------------------------------------------------------------------
+// vCPU
+// -----------------------------------------------------------------------------
+
+namespace test
+{
+
+class vcpu : public eapis::intel_x64::vcpu
+{
+public:
+
+    /// Default Constructor
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    explicit vcpu(vcpuid::type id) :
+        eapis::intel_x64::vcpu{id}
+    { }
+
+    /// Destructor
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    ~vcpu()
+    {
+        std::vector<pci::phys_pci> devices;
+        pci::phys_pci::enumerate(devices);
+
+        if (id() == 0) {
+            for (auto &device : devices) {
+                bfdebug_brk31(0);
+                bfdebug_nhex(0, "Bus", device.bus());
+                bfdebug_nhex(0, "Device", device.device());
+                bfdebug_nhex(0, "Function", device.func());
+                bfdebug_nhex(0, "Vendor ID", device.vendor_id());
+                bfdebug_nhex(0, "Device ID", device.device_id());
+            }
+        }
+    }
+};
+
+}
+
+// -----------------------------------------------------------------------------
+// vCPU Factory
+// -----------------------------------------------------------------------------
+
+namespace bfvmm
+{
+
+std::unique_ptr<vcpu>
+vcpu_factory::make_vcpu(vcpuid::type vcpuid, bfobject *obj)
+{
+    bfignored(obj);
+    return std::make_unique<test::vcpu>(vcpuid);
+}
+
+}

--- a/bfvmm/integration/arch/intel_x64/test_all.sh
+++ b/bfvmm/integration/arch/intel_x64/test_all.sh
@@ -184,6 +184,11 @@ check_vpid()
     return 0
 }
 
+check_phys_pci()
+{
+    return 0
+}
+
 check_vic()
 {
     local spurious_count=$(dmesg | grep -i "spurious" | wc -l)
@@ -348,6 +353,7 @@ check_test()
         *_x64_*msr*) check_msr;;
         *_x64_vic*) check_vic;;
         *_x64_vpid*) check_vpid;;
+        *_x64_phys_pci*) check_phys_pci;;
         *)
             echo ""
             echo -ne "$bold_yellow"

--- a/bfvmm/src/hve/CMakeLists.txt
+++ b/bfvmm/src/hve/CMakeLists.txt
@@ -39,6 +39,7 @@ if(${BUILD_TARGET_ARCH} STREQUAL "x86_64")
         arch/intel_x64/hve.cpp
         arch/intel_x64/ept/helpers.cpp
         arch/intel_x64/ept/memory_map.cpp
+        arch/x64/pci_register.cpp
     )
 
     if (NOT WIN32 AND NOT ENABLE_MOCKING)
@@ -50,8 +51,12 @@ if(${BUILD_TARGET_ARCH} STREQUAL "x86_64")
 elseif(${BUILD_TARGET_ARCH} STREQUAL "aarch64")
     message(WARNING "Unimplemented")
 else()
-    message(FATAL_ERROR "Unsupported archiecture")
+    message(FATAL_ERROR "Unsupported architecture")
 endif()
+
+list(APPEND SOURCES
+    phys_pci.cpp
+)
 
 add_shared_library(
     eapis_hve

--- a/bfvmm/src/hve/arch/x64/pci_register.cpp
+++ b/bfvmm/src/hve/arch/x64/pci_register.cpp
@@ -1,0 +1,132 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <bfgsl.h>
+#include <bfdebug.h>
+#include <bfconstants.h>
+
+#include <hve/pci_register.h>
+#include <intrinsics.h>
+
+using bus_type = eapis::pci::bus_type;
+using device_type = eapis::pci::device_type;
+using func_type = eapis::pci::func_type;
+using register_type = eapis::pci::register_type;
+
+static const x64::portio::port_addr_type PORTIO_CONFIG_ADDRESS = 0xCF8;
+static const x64::portio::port_addr_type PORTIO_CONFIG_DATA    = 0xCFC;
+
+// PCI configuration space address format: see
+// https://wiki.osdev.org/PCI#Configuration_Space_Access_Mechanism_.231
+
+static uint32_t
+config_address(bus_type bus, device_type device, func_type func, register_type reg)
+{
+    const auto ext_bus = static_cast<uint32_t>(bus);
+    const auto ext_dev = static_cast<uint32_t>(device);
+    const auto ext_func = static_cast<uint32_t>(func);
+    const auto ext_reg = static_cast<uint32_t>(reg);
+
+    return ((ext_bus << 16) | (ext_dev << 11) | (ext_func << 8) |
+            (ext_reg & 0xfc) | 0x80000000);
+}
+
+namespace eapis
+{
+
+namespace pci
+{
+
+uint8_t
+read_register_u8(bus_type bus, device_type device, func_type func, register_type reg)
+{
+    const auto address = config_address(bus, device, func, reg);
+
+    x64::portio::outd(PORTIO_CONFIG_ADDRESS, address);
+    uint32_t fullreg = x64::portio::ind(PORTIO_CONFIG_DATA);
+
+    return gsl::narrow_cast<uint8_t>((fullreg >> ((reg & 3) * 8)) & 0xFF);
+}
+
+uint16_t
+read_register_u16(bus_type bus, device_type device, func_type func, register_type reg)
+{
+    const auto address = config_address(bus, device, func, reg);
+
+    x64::portio::outd(PORTIO_CONFIG_ADDRESS, address);
+    uint32_t fullreg = x64::portio::ind(PORTIO_CONFIG_DATA);
+
+    return gsl::narrow_cast<uint16_t>((fullreg >> ((reg & 2) * 8)) & 0xFFFF);
+}
+
+uint32_t
+read_register_u32(bus_type bus, device_type device, func_type func, register_type reg)
+{
+    const auto address = config_address(bus, device, func, reg);
+
+    x64::portio::outd(PORTIO_CONFIG_ADDRESS, address);
+    uint32_t fullreg = x64::portio::ind(PORTIO_CONFIG_DATA);
+
+    return fullreg;
+}
+
+void
+write_register(bus_type bus, device_type device, func_type func, register_type reg,
+               uint32_t value)
+{
+    const uint32_t address = config_address(bus, device, func, reg);
+
+    x64::portio::outd(PORTIO_CONFIG_ADDRESS, address);
+    x64::portio::outd(PORTIO_CONFIG_DATA, value);
+}
+
+void
+rmw_register_u8(bus_type bus, device_type device, func_type func, register_type reg,
+                uint8_t value)
+{
+    const register_type addr32 = gsl::narrow_cast<register_type>(reg & ~0x3u);
+    const uint32_t offset = 8 * (reg & 0x3u);
+    const uint32_t mask = 0xFFu << offset;
+
+    const uint32_t full_reg = read_register_u32(bus, device, func, addr32);
+    const uint32_t full_value = static_cast<uint32_t>(value);
+    const uint32_t masked_reg = full_reg & ~mask;
+    const uint32_t with_new_value = masked_reg | (full_value << offset);
+
+    write_register(bus, device, func, addr32, with_new_value);
+}
+
+void
+rmw_register_u16(bus_type bus, device_type device, func_type func, register_type reg,
+                 uint16_t value)
+{
+    const register_type addr32 = gsl::narrow_cast<register_type>(reg & ~0x2u);
+    const uint32_t offset = 8 * (reg & 0x2u);
+    const uint32_t mask = 0xFFFFu << offset;
+
+    const uint32_t full_reg = read_register_u32(bus, device, func, addr32);
+    const uint32_t full_value = static_cast<uint32_t>(value);
+    const uint32_t masked_reg = full_reg & ~mask;
+    const uint32_t with_new_value = masked_reg | (full_value << offset);
+
+    write_register(bus, device, func, addr32, with_new_value);
+}
+
+}
+
+}

--- a/bfvmm/src/hve/phys_pci.cpp
+++ b/bfvmm/src/hve/phys_pci.cpp
@@ -1,0 +1,111 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <bfgsl.h>
+#include <bfdebug.h>
+#include <bfconstants.h>
+
+#include <hve/phys_pci.h>
+#include <intrinsics.h>
+
+using eapis::pci::phys_pci;
+using bus_type = eapis::pci::bus_type;
+using device_type = eapis::pci::device_type;
+using func_type = eapis::pci::func_type;
+using register_type = eapis::pci::register_type;
+
+namespace eapis
+{
+
+static void enumerate_pci_one_bus(std::vector<phys_pci> &vect, bus_type bus);
+static void enumerate_pci_one_device(std::vector<phys_pci> &vect, bus_type bus,
+                                     device_type device);
+static void enumerate_pci_one_function(std::vector<phys_pci> &vect, bus_type bus,
+                                       device_type device, func_type func);
+static bus_type get_secondary_bus(bus_type bus, device_type device, func_type func);
+
+void pci::phys_pci::enumerate(std::vector<phys_pci> &vect)
+{
+    phys_pci first_host_controller(0, 0, 0);
+
+    if ((first_host_controller.header_type() & 0x80) == 0) {
+        enumerate_pci_one_bus(vect, 0);
+    }
+    else {
+        for (func_type func = 0; func < 8; ++func) {
+            phys_pci host_controller(0, 0, func);
+
+            if (host_controller.vendor_id() != 0xFFFF) {
+                break;
+            }
+
+            enumerate_pci_one_bus(vect, func);
+        }
+    }
+}
+
+static void enumerate_pci_one_bus(std::vector<phys_pci> &vect, bus_type bus)
+{
+    for (device_type device = 0; device < 32; ++device) {
+        enumerate_pci_one_device(vect, bus, device);
+    }
+}
+
+static void enumerate_pci_one_device(std::vector<phys_pci> &vect, bus_type bus,
+                                     device_type device)
+{
+    phys_pci pci_device(bus, device, 0);
+
+    auto vendor = pci_device.vendor_id();
+    if (vendor == 0xFFFF) {
+        return;
+    }
+
+    enumerate_pci_one_function(vect, bus, device, 0);
+
+    if ((pci_device.header_type() & 0x80) != 0) {
+        for (func_type func = 0; func < 8; ++func) {
+            phys_pci pci_func(bus, device, func);
+
+            if (pci_func.vendor_id() != 0xFFFF && func > 0) {
+                enumerate_pci_one_function(vect, bus, device, func);
+            }
+        }
+    }
+}
+static void enumerate_pci_one_function(std::vector<phys_pci> &vect, bus_type bus,
+                                       device_type device, func_type func)
+{
+    phys_pci pci_func(bus, device, func);
+
+    if (pci_func.device_class() == 0x06 && pci_func.device_subclass() == 0x04) {
+        bus_type sec_bus = get_secondary_bus(bus, device, func);
+        enumerate_pci_one_bus(vect, sec_bus);
+    }
+
+    vect.push_back(pci_func);
+}
+
+static bus_type get_secondary_bus(bus_type bus, device_type device,
+                                  func_type func)
+{
+    phys_pci pci_func(bus, device, func);
+    return pci_func.read_register_u8(0x19);
+}
+
+}

--- a/bfvmm/tests/hve/CMakeLists.txt
+++ b/bfvmm/tests/hve/CMakeLists.txt
@@ -66,3 +66,13 @@ do_test(test_isr
     SOURCES arch/intel_x64/test_isr.cpp
     ${ARGN}
 )
+
+do_test(test_phys_pci
+    SOURCES test_phys_pci.cpp
+    ${ARGN}
+)
+
+do_test(test_pci_register
+    SOURCES arch/x64/test_pci_register.cpp
+    ${ARGN}
+)

--- a/bfvmm/tests/hve/arch/x64/test_pci_register.cpp
+++ b/bfvmm/tests/hve/arch/x64/test_pci_register.cpp
@@ -1,0 +1,133 @@
+//
+// Bareflank Extended APIs
+//
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <intrinsics.h>
+#include <support/arch/intel_x64/test_support.h>
+
+#include <hve/pci_register.h>
+
+#define PORTIO_CONFIG_ADDRESS 0xCF8
+#define PORTIO_CONFIG_DATA    0xCFC
+
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
+namespace eapis
+{
+namespace pci
+{
+
+static uint32_t
+reg_from_full_addr(uint32_t full_addr)
+{
+    return full_addr & 0xff;
+}
+
+static auto
+cleanup()
+{
+    return gsl::finally([&] {
+        g_ports.clear();
+    });
+}
+
+TEST_CASE("pci_register test support")
+{
+    CHECK(reg_from_full_addr(0xaabbccdd) == 0xdd);
+
+    g_ports[0x123] = 0x456;
+
+    {
+        auto ___ = cleanup();
+    }
+
+    CHECK(g_ports[0x123] == 0);
+}
+
+TEST_CASE("pci::read_register_uN(bus, device, func, reg)")
+{
+    auto ___ = cleanup();
+
+    g_ports[PORTIO_CONFIG_DATA] = 0xaabbccdd;
+    CHECK(read_register_u32(1, 2, 3, 4) == 0xaabbccdd);
+    CHECK(g_ports[PORTIO_CONFIG_ADDRESS] == 0x80011304);
+
+    CHECK(read_register_u16(1, 2, 3, 4) == 0xccdd);
+    CHECK(g_ports[PORTIO_CONFIG_ADDRESS] == 0x80011304);
+    CHECK(read_register_u16(1, 2, 3, 6) == 0xaabb);
+    CHECK(g_ports[PORTIO_CONFIG_ADDRESS] == 0x80011304);
+
+    CHECK(read_register_u8(1, 2, 3, 4) == 0xdd);
+    CHECK(g_ports[PORTIO_CONFIG_ADDRESS] == 0x80011304);
+    CHECK(read_register_u8(1, 2, 3, 5) == 0xcc);
+    CHECK(g_ports[PORTIO_CONFIG_ADDRESS] == 0x80011304);
+    CHECK(read_register_u8(1, 2, 3, 6) == 0xbb);
+    CHECK(g_ports[PORTIO_CONFIG_ADDRESS] == 0x80011304);
+    CHECK(read_register_u8(1, 2, 3, 7) == 0xaa);
+    CHECK(g_ports[PORTIO_CONFIG_ADDRESS] == 0x80011304);
+}
+
+TEST_CASE("pci::write_register(bus, device, func, reg, value)")
+{
+    auto ___ = cleanup();
+    const uint32_t data = 0x12345678;
+    CHECK_NOTHROW(write_register(1, 2, 3, 4, data));
+    CHECK(g_ports[PORTIO_CONFIG_ADDRESS] == 0x80011304);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0x12345678);
+}
+
+TEST_CASE("pci::rmw_register_uN(bus, device, func, reg, value)")
+{
+    auto ___ = cleanup();
+
+    g_ports[PORTIO_CONFIG_DATA] = 0xaabbccdd;
+    rmw_register_u8(1, 2, 3, 4, 0xff);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xaabbccff);
+    CHECK(g_ports[PORTIO_CONFIG_ADDRESS] == 0x80011304);
+
+    g_ports[PORTIO_CONFIG_DATA] = 0xaabbccdd;
+    rmw_register_u8(1, 2, 3, 5, 0xff);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xaabbffdd);
+    CHECK(g_ports[PORTIO_CONFIG_ADDRESS] == 0x80011304);
+
+    g_ports[PORTIO_CONFIG_DATA] = 0xaabbccdd;
+    rmw_register_u8(1, 2, 3, 6, 0xff);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xaaffccdd);
+    CHECK(g_ports[PORTIO_CONFIG_ADDRESS] == 0x80011304);
+
+    g_ports[PORTIO_CONFIG_DATA] = 0xaabbccdd;
+    rmw_register_u8(1, 2, 3, 7, 0xff);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xffbbccdd);
+    CHECK(g_ports[PORTIO_CONFIG_ADDRESS] == 0x80011304);
+
+    g_ports[PORTIO_CONFIG_DATA] = 0xaabbccdd;
+    rmw_register_u16(1, 2, 3, 4, 0xffff);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xaabbffff);
+    CHECK(g_ports[PORTIO_CONFIG_ADDRESS] == 0x80011304);
+
+    g_ports[PORTIO_CONFIG_DATA] = 0xaabbccdd;
+    rmw_register_u16(1, 2, 3, 6, 0xffff);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xffffccdd);
+    CHECK(g_ports[PORTIO_CONFIG_ADDRESS] == 0x80011304);
+}
+
+
+}
+}
+
+#endif

--- a/bfvmm/tests/hve/dump_pci.py
+++ b/bfvmm/tests/hve/dump_pci.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+#
+# Bareflank Extended APIs
+#
+# Copyright (C) 2018 Assured Information Security, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+import os
+
+devices = sorted(os.listdir("/sys/bus/pci/devices"))
+
+for devname in devices:
+    _, bus, devfunc = devname.split(":")
+    dev, func = devfunc.split(".")
+    bus = int(bus, 16)
+    dev = int(dev, 16)
+    func = int(func, 16)
+
+    config_path = os.path.join("/sys/bus/pci/devices", devname, "config")
+
+    print("{ 0x%02x, 0x%02x, 0x%02x, {" % (bus, dev, func))
+
+    with open(config_path, "rb") as f:
+        for i in range(16):
+            n = int.from_bytes(f.read(4), byteorder='little')
+
+            if i % 4 == 0:
+                print("   ", end='')
+
+            print(" 0x%08x," % n, end='')
+
+            if i % 4 == 3:
+                print()
+
+    print("}},")

--- a/bfvmm/tests/hve/test_phys_pci.cpp
+++ b/bfvmm/tests/hve/test_phys_pci.cpp
@@ -1,0 +1,528 @@
+//
+// Bareflank Extended APIs
+//
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <intrinsics.h>
+
+// To test enumeration, we need a more complicated implementation of _ind and _outd
+// that implement PCI configuration space in a second map.
+#define _ind _simple_ind
+#define _outd _simple_outd
+#include <support/arch/intel_x64/test_support.h>
+#undef _ind
+#undef _outd
+
+#include <hve/phys_pci.h>
+
+#define PORTIO_CONFIG_ADDRESS 0xCF8
+#define PORTIO_CONFIG_DATA    0xCFC
+
+std::map<uint32_t, uint32_t> g_pci_config_space;
+
+extern "C" uint32_t
+_ind(uint16_t port) noexcept
+{
+    if (port == PORTIO_CONFIG_DATA) {
+        auto it = g_pci_config_space.find(g_ports[PORTIO_CONFIG_ADDRESS]);
+        if (it == g_pci_config_space.end()) {
+            return 0xFFFFFFFF;
+        }
+        else {
+            return it->second;
+        }
+    }
+    else {
+        return g_ports[port];
+    }
+}
+
+extern "C" void
+_outd(uint16_t port, uint32_t value) noexcept
+{
+    if (port == PORTIO_CONFIG_DATA) {
+        g_pci_config_space[g_ports[PORTIO_CONFIG_ADDRESS]] = value;
+    }
+
+    g_ports[port] = value;
+}
+
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
+namespace eapis
+{
+namespace pci
+{
+
+static uint32_t
+reg_from_full_addr(uint32_t full_addr)
+{
+    return full_addr & 0xff;
+}
+
+
+static void
+init_all_config_space()
+{
+    for (uint32_t reg = 0; reg <= 0x3C; reg += 4) {
+        uint32_t addr = 0x80011300 | reg;
+        g_pci_config_space[addr] = 0xaabbccdd;
+    }
+
+    g_ports[PORTIO_CONFIG_DATA] = 0xaabbccdd;
+}
+
+static auto
+cleanup()
+{
+    return gsl::finally([&] {
+        g_ports.clear();
+        g_pci_config_space.clear();
+    });
+}
+
+TEST_CASE("phys_pci test support")
+{
+    CHECK(reg_from_full_addr(0xaabbccdd) == 0xdd);
+    CHECK_NOTHROW(init_all_config_space());
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xaabbccdd);
+
+    CHECK_NOTHROW(_outd(1, 2));
+    CHECK(_ind(1) == 2);
+
+    CHECK_NOTHROW(_outd(PORTIO_CONFIG_ADDRESS, 0xABAD1DEA));
+    CHECK(_ind(PORTIO_CONFIG_DATA) == 0xFFFFFFFF);
+
+    for (uint32_t reg = 0; reg <= 0x3C; reg += 4) {
+        CHECK(g_pci_config_space[0x80011300 | reg] == 0xaabbccdd);
+    }
+
+    {
+        auto ___ = cleanup();
+    }
+
+    CHECK(g_pci_config_space[0x80011300] == 0);
+}
+
+TEST_CASE("phys_pci::bus,device,func")
+{
+    phys_pci dev(1, 2, 3);
+    CHECK(dev.bus() == 1);
+    CHECK(dev.device() == 2);
+    CHECK(dev.func() == 3);
+}
+
+TEST_CASE("phys_pci::read/write/rmw(reg[, value])")
+{
+    auto ___ = cleanup();
+
+    phys_pci dev(1, 2, 3);
+    g_pci_config_space[0x80011304] = 0xaabbccdd;
+
+    CHECK(dev.read_register_u8(4) == 0xdd);
+    CHECK(g_ports[PORTIO_CONFIG_ADDRESS] == 0x80011304);
+
+    CHECK(dev.read_register_u16(4) == 0xccdd);
+    CHECK(g_ports[PORTIO_CONFIG_ADDRESS] == 0x80011304);
+
+    CHECK(dev.read_register_u32(4) == 0xaabbccdd);
+    CHECK(g_ports[PORTIO_CONFIG_ADDRESS] == 0x80011304);
+
+    CHECK_NOTHROW(dev.write_register(4, 0xffffffff));
+    CHECK(g_ports[PORTIO_CONFIG_ADDRESS] == 0x80011304);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xffffffff);
+
+    g_pci_config_space[0x80011304] = 0xaabbccdd;
+    CHECK_NOTHROW(dev.rmw_register_u8(4, 0xff));
+    CHECK(g_ports[PORTIO_CONFIG_ADDRESS] == 0x80011304);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xaabbccff);
+
+    g_pci_config_space[0x80011304] = 0xaabbccdd;
+    CHECK_NOTHROW(dev.rmw_register_u16(4, 0xffff));
+    CHECK(g_ports[PORTIO_CONFIG_ADDRESS] == 0x80011304);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xaabbffff);
+}
+
+TEST_CASE("phys_pci named register reads")
+{
+    auto ___ = cleanup();
+    phys_pci dev(1, 2, 3);
+
+    init_all_config_space();
+
+    CHECK(dev.device_id() == 0xaabb);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x00);
+
+    CHECK(dev.vendor_id() == 0xccdd);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x00);
+
+    CHECK(dev.status() == 0xaabb);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x04);
+
+    CHECK(dev.read_command() == 0xccdd);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x04);
+
+    CHECK(dev.device_class() == 0xaa);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x08);
+
+    CHECK(dev.device_subclass() == 0xbb);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x08);
+
+    CHECK(dev.prog_if() == 0xcc);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x08);
+
+    CHECK(dev.revision() == 0xdd);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x08);
+
+    CHECK(dev.read_bist() == 0xaa);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x0C);
+
+    CHECK(dev.header_type() == 0xbb);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x0C);
+
+    CHECK(dev.latency() == 0xcc);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x0C);
+
+    CHECK(dev.cl_size() == 0xdd);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x0C);
+
+    CHECK(dev.cisp() == 0xaabbccdd);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x28);
+
+    CHECK(dev.subsystem_id() == 0xaabb);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x2C);
+
+    CHECK(dev.subsystem_vid() == 0xccdd);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x2C);
+
+    CHECK(dev.exprom_bar() == 0xaabbccdd);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x30);
+
+    CHECK(dev.capabilities_ptr() == 0xdd);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x34);
+
+    CHECK(dev.max_latency() == 0xaa);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x3C);
+
+    CHECK(dev.min_grant() == 0xbb);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x3C);
+
+    CHECK(dev.int_pin() == 0xcc);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x3C);
+
+    CHECK(dev.int_line() == 0xdd);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x3C);
+
+    CHECK(dev.bar(0) == 0xaabbccdd);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x10);
+
+    CHECK(dev.bar(1) == 0xaabbccdd);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x14);
+
+    CHECK(dev.bar(2) == 0xaabbccdd);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x18);
+
+    CHECK(dev.bar(3) == 0xaabbccdd);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x1C);
+
+    CHECK(dev.bar(4) == 0xaabbccdd);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x20);
+
+    CHECK(dev.bar(5) == 0xaabbccdd);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x24);
+
+    CHECK(dev.bar(6) == 0xffffffff);
+}
+
+TEST_CASE("phys_pci named register writes")
+{
+    auto ___ = cleanup();
+    phys_pci dev(1, 2, 3);
+
+    init_all_config_space();
+    dev.send_command(0xffff);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x04);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xaabbffff);
+
+    init_all_config_space();
+    dev.send_bist(0xff);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x0C);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xffbbccdd);
+
+    init_all_config_space();
+    dev.set_latency(0xff);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x0C);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xaabbffdd);
+
+    init_all_config_space();
+    dev.set_cl_size(0xff);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x0C);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xaabbccff);
+
+    init_all_config_space();
+    dev.set_exprom_bar(0xffffffff);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x30);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xffffffff);
+
+    init_all_config_space();
+    dev.set_int_line(0xff);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x3C);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xaabbccff);
+
+    init_all_config_space();
+    dev.set_bar(0, 0xffffffff);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x10);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xffffffff);
+
+    init_all_config_space();
+    dev.set_bar(1, 0xffffffff);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x14);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xffffffff);
+
+    init_all_config_space();
+    dev.set_bar(2, 0xffffffff);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x18);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xffffffff);
+
+    init_all_config_space();
+    dev.set_bar(3, 0xffffffff);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x1C);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xffffffff);
+
+    init_all_config_space();
+    dev.set_bar(4, 0xffffffff);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x20);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xffffffff);
+
+    init_all_config_space();
+    dev.set_bar(5, 0xffffffff);
+    CHECK(reg_from_full_addr(g_ports[PORTIO_CONFIG_ADDRESS]) == 0x24);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xffffffff);
+
+    init_all_config_space();
+    g_ports[PORTIO_CONFIG_ADDRESS] = 0;
+    dev.set_bar(6, 0xffffffff);
+    CHECK(g_ports[PORTIO_CONFIG_ADDRESS] == 0);
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xaabbccdd);
+}
+
+// Sample PCI descriptors to test enumeration
+
+struct pci_descriptor {
+    uint8_t bus;
+    uint8_t device;
+    uint8_t func;
+    uint32_t data[16];
+};
+
+// Taken from a real system using ./dump_pci.py
+static const struct pci_descriptor g_descriptors[] = {
+    {
+        0x00, 0x00, 0x00, {
+            0x591f8086, 0x20900006, 0x06000005, 0x00000000,
+            0x00000000, 0x00000000, 0x00000000, 0x00000000,
+            0x00000000, 0x00000000, 0x00000000, 0x50001458,
+            0x00000000, 0x000000e0, 0x00000000, 0x00000000,
+        }
+    },
+    {
+        0x00, 0x02, 0x00, {
+            0x59128086, 0x00100407, 0x03000004, 0x00000010,
+            0xf6000004, 0x00000000, 0xe000000c, 0x00000000,
+            0x0000f001, 0x00000000, 0x00000000, 0xd0001458,
+            0x00000000, 0x00000040, 0x00000000, 0x0000010b,
+        }
+    },
+    {
+        0x00, 0x08, 0x00, {
+            0x19118086, 0x00100000, 0x08800000, 0x00000010,
+            0xf722e004, 0x00000000, 0x00000000, 0x00000000,
+            0x00000000, 0x00000000, 0x00000000, 0x50001458,
+            0x00000000, 0x00000090, 0x00000000, 0x0000010b,
+        }
+    },
+    {
+        0x00, 0x14, 0x00, {
+            0xa2af8086, 0x02900406, 0x0c033000, 0x00800000,
+            0xf7210004, 0x00000000, 0x00000000, 0x00000000,
+            0x00000000, 0x00000000, 0x00000000, 0x50071458,
+            0x00000000, 0x00000070, 0x00000000, 0x0000010b,
+        }
+    },
+    {
+        0x00, 0x16, 0x00, {
+            0xa2ba8086, 0x00100406, 0x07800000, 0x00800000,
+            0xf722d004, 0x00000000, 0x00000000, 0x00000000,
+            0x00000000, 0x00000000, 0x00000000, 0x1c3a1458,
+            0x00000000, 0x00000050, 0x00000000, 0x0000010b,
+        }
+    },
+    {
+        0x00, 0x17, 0x00, {
+            0xa2828086, 0x02b00407, 0x01060100, 0x00000000,
+            0xf7228000, 0xf722c000, 0x0000f091, 0x0000f081,
+            0x0000f061, 0xf722b000, 0x00000000, 0xb0051458,
+            0x00000000, 0x00000080, 0x00000000, 0x0000010b,
+        }
+    },
+    {
+        0x00, 0x1b, 0x00, {
+            0xa2eb8086, 0x00100007, 0x060400f0, 0x00810010,
+            0x00000000, 0x00000000, 0x00010100, 0x200000f0,
+            0xf710f710, 0x0001fff1, 0x00000000, 0x00000000,
+            0x00000000, 0x00000040, 0x00000000, 0x0010010b,
+        }
+    },
+    {
+        0x00, 0x1c, 0x00, {
+            0xa2948086, 0x00100007, 0x060400f0, 0x00810010,
+            0x00000000, 0x00000000, 0x00020200, 0x2000e0e0,
+            0xf700f700, 0xf001f001, 0x00000000, 0x00000000,
+            0x00000000, 0x00000040, 0x00000000, 0x0010010b,
+        }
+    },
+    {
+        0x00, 0x1c, 0x05, {
+            0xa2958086, 0x00100007, 0x060400f0, 0x00810010,
+            0x00000000, 0x00000000, 0x00030300, 0x200000f0,
+            0x0000fff0, 0x0001fff1, 0x00000000, 0x00000000,
+            0x00000000, 0x00000040, 0x00000000, 0x0010020a,
+        }
+    },
+    {
+        0x00, 0x1c, 0x06, {
+            0xa2968086, 0x00100007, 0x060400f0, 0x00810010,
+            0x00000000, 0x00000000, 0x00040400, 0x200000f0,
+            0x0000fff0, 0x0001fff1, 0x00000000, 0x00000000,
+            0x00000000, 0x00000040, 0x00000000, 0x0010030b,
+        }
+    },
+    {
+        0x00, 0x1c, 0x07, {
+            0xa2978086, 0x00100007, 0x060400f0, 0x00810010,
+            0x00000000, 0x00000000, 0x00050500, 0x200000f0,
+            0x0000fff0, 0x0001fff1, 0x00000000, 0x00000000,
+            0x00000000, 0x00000040, 0x00000000, 0x0010040b,
+        }
+    },
+    {
+        0x00, 0x1d, 0x00, {
+            0xa2988086, 0x00100007, 0x060400f0, 0x00810010,
+            0x00000000, 0x00000000, 0x00060600, 0x200000f0,
+            0x0000fff0, 0x0001fff1, 0x00000000, 0x00000000,
+            0x00000000, 0x00000040, 0x00000000, 0x0010010b,
+        }
+    },
+    {
+        0x00, 0x1d, 0x01, {
+            0xa2998086, 0x00100007, 0x060400f0, 0x00810010,
+            0x00000000, 0x00000000, 0x00070700, 0x200000f0,
+            0x0000fff0, 0x0001fff1, 0x00000000, 0x00000000,
+            0x00000000, 0x00000040, 0x00000000, 0x0010020a,
+        }
+    },
+    {
+        0x00, 0x1d, 0x02, {
+            0xa29a8086, 0x00100007, 0x060400f0, 0x00810010,
+            0x00000000, 0x00000000, 0x00080800, 0x200000f0,
+            0x0000fff0, 0x0001fff1, 0x00000000, 0x00000000,
+            0x00000000, 0x00000040, 0x00000000, 0x0010030b,
+        }
+    },
+    {
+        0x00, 0x1d, 0x03, {
+            0xa29b8086, 0x00100007, 0x060400f0, 0x00810010,
+            0x00000000, 0x00000000, 0x00090900, 0x200000f0,
+            0x0000fff0, 0x0001fff1, 0x00000000, 0x00000000,
+            0x00000000, 0x00000040, 0x00000000, 0x0010040b,
+        }
+    },
+    {
+        0x00, 0x1f, 0x00, {
+            0xa2c88086, 0x02000007, 0x06010000, 0x00800000,
+            0x00000000, 0x00000000, 0x00000000, 0x00000000,
+            0x00000000, 0x00000000, 0x00000000, 0x50011458,
+            0x00000000, 0x00000000, 0x00000000, 0x00000000,
+        }
+    },
+    {
+        0x00, 0x1f, 0x02, {
+            0xa2a18086, 0x00000000, 0x05800000, 0x00800000,
+            0xf7224000, 0x00000000, 0x00000000, 0x00000000,
+            0x00000000, 0x00000000, 0x00000000, 0x50011458,
+            0x00000000, 0x00000000, 0x00000000, 0x00000000,
+        }
+    },
+    {
+        0x00, 0x1f, 0x03, {
+            0xa2f08086, 0x00100406, 0x04030000, 0x00002010,
+            0xf7220004, 0x00000000, 0x00000000, 0x00000000,
+            0xf7200004, 0x00000000, 0x00000000, 0xa1821458,
+            0x00000000, 0x00000050, 0x00000000, 0x0000010b,
+        }
+    },
+    {
+        0x00, 0x1f, 0x04, {
+            0xa2a38086, 0x02800003, 0x0c050000, 0x00000000,
+            0xf722a004, 0x00000000, 0x00000000, 0x00000000,
+            0x0000f041, 0x00000000, 0x00000000, 0x50011458,
+            0x00000000, 0x00000000, 0x00000000, 0x0000010b,
+        }
+    },
+    {
+        0x01, 0x00, 0x00, {
+            0xa804144d, 0x00100406, 0x01080200, 0x00000010,
+            0xf7100004, 0x00000000, 0x00000000, 0x00000000,
+            0x00000000, 0x00000000, 0x00000000, 0xa801144d,
+            0x00000000, 0x00000040, 0x00000000, 0x0000010b,
+        }
+    },
+    {
+        0x02, 0x00, 0x00, {
+            0x816810ec, 0x00100407, 0x0200000c, 0x00000010,
+            0x0000e001, 0x00000000, 0xf7000004, 0x00000000,
+            0xf000000c, 0x00000000, 0x00000000, 0xe0001458,
+            0x00000000, 0x00000040, 0x00000000, 0x0000010b,
+        }
+    },
+};
+
+TEST_CASE("enumeration")
+{
+    auto ___ = cleanup();
+
+    for (const auto &descriptor : g_descriptors) {
+        for (register_type reg = 0; reg <= 0x3C; ++reg) {
+            write_register(
+                descriptor.bus,
+                descriptor.device,
+                descriptor.func,
+                reg,
+                descriptor.data[reg / 4]);
+        }
+    }
+
+    std::vector<phys_pci> devices;
+
+    CHECK_NOTHROW(phys_pci::enumerate(devices));
+    CHECK(devices.size() == sizeof(g_descriptors) / sizeof(g_descriptors[0]));
+}
+
+}
+}
+
+#endif


### PR DESCRIPTION
Add a class `eapis::phys_pci` representing physical PCI devices' configuration space with an implementation for x64. Includes integration test to enumerate and dump the system's entire PCI tree.