### PR TITLE
Fix codacy issues

### DIFF
--- a/bfvmm/integration/arch/intel_x64/control_register/trap_cr0.cpp
+++ b/bfvmm/integration/arch/intel_x64/control_register/trap_cr0.cpp
@@ -51,7 +51,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    vcpu(vcpuid::type id) :
+    explicit vcpu(vcpuid::type id) :
         eapis::intel_x64::vcpu{id}
     {
         hve()->enable_wrcr0_exiting(

--- a/bfvmm/integration/arch/intel_x64/control_register/trap_cr3.cpp
+++ b/bfvmm/integration/arch/intel_x64/control_register/trap_cr3.cpp
@@ -46,7 +46,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    vcpu(vcpuid::type id) :
+    explicit vcpu(vcpuid::type id) :
         eapis::intel_x64::vcpu{id}
     {
         hve()->add_rdcr3_handler(

--- a/bfvmm/integration/arch/intel_x64/control_register/trap_cr4.cpp
+++ b/bfvmm/integration/arch/intel_x64/control_register/trap_cr4.cpp
@@ -53,7 +53,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    vcpu(vcpuid::type id) :
+    explicit vcpu(vcpuid::type id) :
         eapis::intel_x64::vcpu{id}
     {
         hve()->enable_wrcr4_exiting(

--- a/bfvmm/integration/arch/intel_x64/control_register/trap_cr8.cpp
+++ b/bfvmm/integration/arch/intel_x64/control_register/trap_cr8.cpp
@@ -37,7 +37,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    vcpu(vcpuid::type id) :
+    explicit vcpu(vcpuid::type id) :
         eapis::intel_x64::vcpu{id}
     {
         m_tpr_shadow = ::intel_x64::cr8::get();

--- a/bfvmm/integration/arch/intel_x64/cpuid/trap_cpuid.cpp
+++ b/bfvmm/integration/arch/intel_x64/cpuid/trap_cpuid.cpp
@@ -55,7 +55,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    vcpu(vcpuid::type id) :
+    explicit vcpu(vcpuid::type id) :
         eapis::intel_x64::vcpu{id}
     {
         hve()->add_cpuid_handler(

--- a/bfvmm/integration/arch/intel_x64/io_instruction/trap_in_out.cpp
+++ b/bfvmm/integration/arch/intel_x64/io_instruction/trap_in_out.cpp
@@ -46,7 +46,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    vcpu(vcpuid::type id) :
+    explicit vcpu(vcpuid::type id) :
         eapis::intel_x64::vcpu{id}
     {
         hve()->add_io_instruction_handler(

--- a/bfvmm/integration/arch/intel_x64/monitor_trap/single_step_cpuid.cpp
+++ b/bfvmm/integration/arch/intel_x64/monitor_trap/single_step_cpuid.cpp
@@ -37,7 +37,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    vcpu(vcpuid::type id) :
+    explicit vcpu(vcpuid::type id) :
         eapis::intel_x64::vcpu{id}
     {
         hve()->add_cpuid_handler(

--- a/bfvmm/integration/arch/intel_x64/mov_dr/trap_dr7.cpp
+++ b/bfvmm/integration/arch/intel_x64/mov_dr/trap_dr7.cpp
@@ -46,7 +46,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    vcpu(vcpuid::type id) :
+    explicit vcpu(vcpuid::type id) :
         eapis::intel_x64::vcpu{id}
     {
         hve()->add_mov_dr_handler(

--- a/bfvmm/integration/arch/intel_x64/rdmsr/trap_rdmsr.cpp
+++ b/bfvmm/integration/arch/intel_x64/rdmsr/trap_rdmsr.cpp
@@ -46,7 +46,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    vcpu(vcpuid::type id) :
+    explicit vcpu(vcpuid::type id) :
         eapis::intel_x64::vcpu{id}
     {
         hve()->add_rdmsr_handler(

--- a/bfvmm/integration/arch/intel_x64/test_all.sh
+++ b/bfvmm/integration/arch/intel_x64/test_all.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
+
+set -e
 
 reset="\e[0m"
 bold="\e[1m"

--- a/bfvmm/integration/arch/intel_x64/vic/test_injection.cpp
+++ b/bfvmm/integration/arch/intel_x64/vic/test_injection.cpp
@@ -33,7 +33,7 @@ public:
     ///
     /// @param hve the address of the hve for this vic
     ///
-    vcpu(vcpuid::type id) : eapis::intel_x64::vcpu{id}
+    explicit vcpu(vcpuid::type id) : eapis::intel_x64::vcpu{id}
     {
         const auto phys_svr = vic()->m_phys_lapic->read_svr();
         const auto piv = ::intel_x64::lapic::svr::vector::get(phys_svr);

--- a/bfvmm/integration/arch/intel_x64/vpid/enable_vpid.cpp
+++ b/bfvmm/integration/arch/intel_x64/vpid/enable_vpid.cpp
@@ -37,7 +37,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    vcpu(vcpuid::type id) :
+    explicit vcpu(vcpuid::type id) :
         eapis::intel_x64::vcpu{id}
     {
         hve()->enable_vpid();

--- a/bfvmm/integration/arch/intel_x64/wrmsr/trap_wrmsr.cpp
+++ b/bfvmm/integration/arch/intel_x64/wrmsr/trap_wrmsr.cpp
@@ -46,7 +46,7 @@ public:
     /// @expects
     /// @ensures
     ///
-    vcpu(vcpuid::type id) :
+    explicit vcpu(vcpuid::type id) :
         eapis::intel_x64::vcpu{id}
     {
         hve()->add_wrmsr_handler(


### PR DESCRIPTION
- Use explicit for integration vcpu constructors
- Move -e to 'set -e' so that codacy picks up the shebang

Signed-off-by: Connor Davis <davisc@ainfosec.com>