### PR TITLE
test_phys_pci: more accurate emulation of BAR length query

### DIFF
--- a/bfvmm/tests/hve/test_phys_pci.cpp
+++ b/bfvmm/tests/hve/test_phys_pci.cpp
@@ -96,7 +96,8 @@ intercept_bar_write(uint32_t addr, uint32_t value)
             return 0xFFFFFFFF;
         }
         else {
-            return ~(BAR_TEST_REGION_LENGTH - 1);
+            uint32_t old_value = g_pci_config_space[addr];
+            return (~(BAR_TEST_REGION_LENGTH - 1u) & 0xFFFFFFFE) | (old_value & 0x1);
         }
     }
     else {


### PR DESCRIPTION
PCI specifies the least significant bit in a BAR as read-only - for accurate testing, make sure our BAR write test doesn't clobber that bit.