### PR TITLE
Refactored EPT unit test support code

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,7 +40,7 @@ build_script:
   #
   # Visual Studio (MSBuild / Static Libraries)
   #
-  - git clone -b test-support https://github.com/connojd/hypervisor.git hypervisor
+  - git clone https://github.com/bareflank/hypervisor.git hypervisor
   - mkdir hypervisor\build
   - cd hypervisor\build
   - cmake -G "Visual Studio 15 2017 Win64" -DEXTENSION=..\.. -DENABLE_BUILD_VMM=OFF -DENABLE_BUILD_USERSPACE=OFF -DENABLE_BUILD_TEST=ON ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
   #
   # Build Folder
   #
-  - git clone -b test-support https://github.com/connojd/hypervisor.git hypervisor
+  - git clone https://github.com/bareflank/hypervisor.git hypervisor
   - mkdir build
   - cd build
 

--- a/bfvmm/tests/hve/CMakeLists.txt
+++ b/bfvmm/tests/hve/CMakeLists.txt
@@ -32,15 +32,18 @@ do_test(test_page_table_entry
     ${ARGN}
 )
 
-# do_test(test_memory_map
-#     SOURCES arch/intel_x64/ept/test_memory_map.cpp
-#     ${ARGN}
-# )
-#
-# do_test(test_ept_helpers
-#     SOURCES arch/intel_x64/ept/test_helpers.cpp
-#     ${ARGN}
-# )
+do_test(test_memory_map
+    SOURCES arch/intel_x64/ept/test_memory_map.cpp
+    SOURCES arch/intel_x64/ept/ept_test_support.cpp
+    CMD_LINE_ARGS ASAN_OPTIONS=detect_leaks=0
+    ${ARGN}
+)
+
+do_test(test_ept_helpers
+    SOURCES arch/intel_x64/ept/test_helpers.cpp
+    SOURCES arch/intel_x64/ept/ept_test_support.cpp
+    ${ARGN}
+)
 
 do_test(test_vpid
     SOURCES arch/intel_x64/test_vpid.cpp

--- a/bfvmm/tests/hve/arch/intel_x64/ept/ept_test_support.cpp
+++ b/bfvmm/tests/hve/arch/intel_x64/ept/ept_test_support.cpp
@@ -1,0 +1,291 @@
+//
+// Bareflank Extended APIs
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include "ept_test_support.h"
+
+namespace test_ept
+{
+
+ept_test_support::ept_test_support(HippoMocks::MockRepository &mocks)
+{
+    m_mock_mm = mocks.Mock<bfvmm::memory_manager>();
+    mocks.OnCallFunc(bfvmm::memory_manager::instance).Return(m_mock_mm);
+
+    mocks.OnCall(m_mock_mm, bfvmm::memory_manager::virtptr_to_physint).Do(
+    [&](auto hva) { return this->mock_virtptr_to_physint(hva); });
+
+    mocks.OnCall(m_mock_mm, bfvmm::memory_manager::virtint_to_physint).Do(
+    [&](auto hva) { return this->mock_virtint_to_physint(hva); });
+
+    mocks.OnCall(m_mock_mm, bfvmm::memory_manager::virtptr_to_physptr).Do(
+    [&](auto hva) { return this->mock_virtptr_to_physptr(hva); });
+
+    mocks.OnCall(m_mock_mm, bfvmm::memory_manager::virtint_to_physptr).Do(
+    [&](auto hva) { return this->mock_virtint_to_physptr(hva); });
+
+    mocks.OnCall(m_mock_mm, bfvmm::memory_manager::physint_to_virtptr).Do(
+    [&](auto hpa) { return this->mock_physint_to_virtptr(hpa); });
+
+    mocks.OnCall(m_mock_mm, bfvmm::memory_manager::physint_to_virtint).Do(
+    [&](auto hpa) { return this->mock_physint_to_virtint(hpa); });
+
+    mocks.OnCall(m_mock_mm, bfvmm::memory_manager::physptr_to_virtptr).Do(
+    [&](auto hpa) { return this->mock_physptr_to_virtptr(hpa); });
+
+    mocks.OnCall(m_mock_mm, bfvmm::memory_manager::physptr_to_virtint).Do(
+    [&](auto hpa) { return this->mock_physptr_to_virtint(hpa); });
+}
+
+void
+ept_test_support::add_mock_mapping(ept::gpa_t hva, ept::hpa_t hpa)
+{
+    m_mock_mem[hva] = hpa;
+}
+
+void
+ept_test_support::setup_mock_empty_pml4(ept::memory_map &map)
+{
+    this->reset(map);
+    m_saved_pml4_hva = map.m_pml4_hva;
+
+    for (auto entry : gsl::make_span(m_pml4.get(), ept::page_table::num_entries)) {
+        entry = 0ULL;
+    }
+
+    map.m_pml4_hva = reinterpret_cast<uintptr_t>(m_pml4.get());
+    add_mock_mapping(reinterpret_cast<uintptr_t>(m_pml4.get()), mock_pml4_hpa);
+}
+
+void
+ept_test_support::setup_mock_1g_page(ept::memory_map &map)
+{
+    this->reset(map);
+    m_saved_pml4_hva = map.m_pml4_hva;
+
+    auto pml4_view = gsl::make_span(m_pml4.get(), ept::page_table::num_entries);
+    auto first_entry = pml4_view.begin();
+    auto last_entry = pml4_view.end() - 1;
+    ept::epte::clear(*first_entry);
+    ept::epte::clear(*last_entry);
+    ept::epte::read_access::enable(*last_entry);
+    ept::epte::write_access::enable(*last_entry);
+    ept::epte::set_hpa(*last_entry, mock_pdpt_hpa & ept::epte::phys_addr_bits::mask);
+
+    auto pdpt_view = gsl::make_span(m_pdpt.get(), ept::page_table::num_entries);
+    first_entry = pdpt_view.begin();
+    last_entry = pdpt_view.end() - 1;
+    ept::epte::clear(*first_entry);
+    ept::epte::clear(*last_entry);
+    ept::epte::read_access::enable(*last_entry);
+    ept::epte::write_access::enable(*last_entry);
+    ept::epte::entry_type::enable(*last_entry);
+    ept::epte::set_hpa(*last_entry, mock_page_hpa & ept::epte::phys_addr_bits::mask);
+
+    map.m_pml4_hva = reinterpret_cast<uintptr_t>(m_pml4.get());
+    add_mock_mapping(reinterpret_cast<uintptr_t>(m_pml4.get()), mock_pml4_hpa);
+    add_mock_mapping(reinterpret_cast<uintptr_t>(m_pdpt.get()), mock_pdpt_hpa);
+    add_mock_mapping(reinterpret_cast<uintptr_t>(m_page.get()), mock_page_hpa);
+}
+
+void
+ept_test_support::setup_mock_2m_page(ept::memory_map &map)
+{
+    this->reset(map);
+    m_saved_pml4_hva = map.m_pml4_hva;
+
+    auto pml4_view = gsl::make_span(m_pml4.get(), ept::page_table::num_entries);
+    auto first_entry = pml4_view.begin();
+    auto last_entry = pml4_view.end() - 1;
+    ept::epte::clear(*first_entry);
+    ept::epte::clear(*last_entry);
+    ept::epte::read_access::enable(*last_entry);
+    ept::epte::write_access::enable(*last_entry);
+    ept::epte::set_hpa(*last_entry, mock_pdpt_hpa & ept::epte::phys_addr_bits::mask);
+
+    auto pdpt_view = gsl::make_span(m_pdpt.get(), ept::page_table::num_entries);
+    first_entry = pdpt_view.begin();
+    last_entry = pdpt_view.end() - 1;
+    ept::epte::clear(*first_entry);
+    ept::epte::clear(*last_entry);
+    ept::epte::read_access::enable(*last_entry);
+    ept::epte::write_access::enable(*last_entry);
+    ept::epte::set_hpa(*last_entry, mock_pd_hpa & ept::epte::phys_addr_bits::mask);
+
+    auto pd_view = gsl::make_span(m_pd.get(), ept::page_table::num_entries);
+    first_entry = pd_view.begin();
+    last_entry = pd_view.end() - 1;
+    ept::epte::clear(*first_entry);
+    ept::epte::clear(*last_entry);
+    ept::epte::read_access::enable(*last_entry);
+    ept::epte::write_access::enable(*last_entry);
+    ept::epte::entry_type::enable(*last_entry);
+    ept::epte::set_hpa(*last_entry, mock_page_hpa & ept::epte::phys_addr_bits::mask);
+
+    map.m_pml4_hva = reinterpret_cast<uintptr_t>(m_pml4.get());
+    add_mock_mapping(reinterpret_cast<uintptr_t>(m_pml4.get()), mock_pml4_hpa);
+    add_mock_mapping(reinterpret_cast<uintptr_t>(m_pdpt.get()), mock_pdpt_hpa);
+    add_mock_mapping(reinterpret_cast<uintptr_t>(m_pd.get()), mock_pd_hpa);
+    add_mock_mapping(reinterpret_cast<uintptr_t>(m_page.get()), mock_page_hpa);
+}
+
+void
+ept_test_support::setup_mock_4k_page(ept::memory_map &map)
+{
+    this->reset(map);
+    m_saved_pml4_hva = map.m_pml4_hva;
+
+    auto pml4_view = gsl::make_span(m_pml4.get(), ept::page_table::num_entries);
+    auto first_entry = pml4_view.begin();
+    auto last_entry = pml4_view.end() - 1;
+    ept::epte::clear(*first_entry);
+    ept::epte::clear(*last_entry);
+    ept::epte::read_access::enable(*last_entry);
+    ept::epte::write_access::enable(*last_entry);
+    ept::epte::set_hpa(*last_entry, mock_pdpt_hpa & ept::epte::phys_addr_bits::mask);
+
+    auto pdpt_view = gsl::make_span(m_pdpt.get(), ept::page_table::num_entries);
+    first_entry = pdpt_view.begin();
+    last_entry = pdpt_view.end() - 1;
+    ept::epte::clear(*first_entry);
+    ept::epte::clear(*last_entry);
+    ept::epte::read_access::enable(*last_entry);
+    ept::epte::write_access::enable(*last_entry);
+    ept::epte::set_hpa(*last_entry, mock_pd_hpa & ept::epte::phys_addr_bits::mask);
+
+    auto pd_view = gsl::make_span(m_pd.get(), ept::page_table::num_entries);
+    first_entry = pd_view.begin();
+    last_entry = pd_view.end() - 1;
+    ept::epte::clear(*first_entry);
+    ept::epte::clear(*last_entry);
+    ept::epte::read_access::enable(*last_entry);
+    ept::epte::write_access::enable(*last_entry);
+    ept::epte::set_hpa(*last_entry, mock_pt_hpa & ept::epte::phys_addr_bits::mask);
+
+    auto pt_view = gsl::make_span(m_pt.get(), ept::page_table::num_entries);
+    first_entry = pt_view.begin();
+    last_entry = pt_view.end() - 1;
+    ept::epte::clear(*first_entry);
+    ept::epte::clear(*last_entry);
+    ept::epte::read_access::enable(*last_entry);
+    ept::epte::write_access::enable(*last_entry);
+    ept::epte::entry_type::enable(*last_entry);
+    ept::epte::set_hpa(*last_entry, mock_page_hpa & ept::epte::phys_addr_bits::mask);
+
+    map.m_pml4_hva = reinterpret_cast<uintptr_t>(m_pml4.get());
+    add_mock_mapping(reinterpret_cast<uintptr_t>(m_pml4.get()), mock_pml4_hpa);
+    add_mock_mapping(reinterpret_cast<uintptr_t>(m_pdpt.get()), mock_pdpt_hpa);
+    add_mock_mapping(reinterpret_cast<uintptr_t>(m_pd.get()), mock_pd_hpa);
+    add_mock_mapping(reinterpret_cast<uintptr_t>(m_pt.get()), mock_pt_hpa);
+    add_mock_mapping(reinterpret_cast<uintptr_t>(m_page.get()), mock_page_hpa);
+}
+
+void
+ept_test_support::reset(ept::memory_map &map)
+{
+    m_mock_mem.clear();
+    m_next_phys_addr = 0xF00D0000;
+
+    for (auto entry : gsl::make_span(m_pml4.get(), ept::page_table::num_entries)) {
+        entry = 0xffffffffffffffff;
+    }
+
+    for (auto entry : gsl::make_span(m_pdpt.get(), ept::page_table::num_entries)) {
+        entry = 0xffffffffffffffff;
+    }
+
+    for (auto entry : gsl::make_span(m_pd.get(), ept::page_table::num_entries)) {
+        entry = 0xffffffffffffffff;
+    }
+
+    for (auto entry : gsl::make_span(m_pt.get(), ept::page_table::num_entries)) {
+        entry = 0xffffffffffffffff;
+    }
+
+    for (auto entry : gsl::make_span(m_page.get(), ept::page_table::num_entries)) {
+        entry = gsl::byte(0xff);
+    }
+
+    if (m_saved_pml4_hva) {
+        map.m_pml4_hva = m_saved_pml4_hva;
+        m_saved_pml4_hva = 0;
+    }
+}
+
+uintptr_t
+ept_test_support::mock_virtptr_to_physint(void *hva)
+{
+    return mock_virtint_to_physint(reinterpret_cast<ept::hva_t>(hva));
+}
+
+void *
+ept_test_support::mock_virtptr_to_physptr(void *hva)
+{
+    return reinterpret_cast<void *>(mock_virtptr_to_physint(hva));
+}
+
+uintptr_t
+ept_test_support::mock_virtint_to_physint(uintptr_t hva)
+{
+    if (m_mock_mem.count(hva)) {
+        return m_mock_mem.at(hva);
+    }
+
+    m_next_phys_addr += 0x1000;
+    m_mock_mem[hva] = m_next_phys_addr;
+    return m_next_phys_addr;
+}
+
+void *
+ept_test_support::mock_virtint_to_physptr(uintptr_t hva)
+{
+    return reinterpret_cast<void *>(mock_virtint_to_physint(hva));
+}
+
+void *
+ept_test_support::mock_physint_to_virtptr(uintptr_t hpa)
+{
+    return reinterpret_cast<void *>(mock_physint_to_virtint(hpa));
+}
+
+void *
+ept_test_support::mock_physptr_to_virtptr(void *hpa)
+{
+    return mock_physint_to_virtptr(reinterpret_cast<uintptr_t>(hpa));
+}
+
+uintptr_t
+ept_test_support::mock_physint_to_virtint(uintptr_t hpa)
+{
+    for (auto const &x : m_mock_mem) {
+        if (x.second == hpa) {
+            return x.first;
+        }
+    }
+    std::stringstream msg;
+    msg << "invalid test guest physical address: " << std::hex << "0x" << hpa;
+    throw std::logic_error(msg.str().c_str());
+}
+
+uintptr_t
+ept_test_support::mock_physptr_to_virtint(void *hpa)
+{
+    return reinterpret_cast<uintptr_t>(mock_physptr_to_virtptr(hpa));
+}
+
+}

--- a/bfvmm/tests/hve/arch/intel_x64/ept/ept_test_support.h
+++ b/bfvmm/tests/hve/arch/intel_x64/ept/ept_test_support.h
@@ -17,20 +17,20 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#ifndef EPT_TEST_SUPPORT_H
+#define EPT_TEST_SUPPORT_H
+
 #include <catch/catch.hpp>
 #include <hippomocks.h>
 
 #include <bfvmm/memory_manager/memory_manager.h>
 
 #include <hve/arch/intel_x64/ept.h>
-#include <support/arch/intel_x64/test_support.h>
 
-namespace eapis
+namespace test_ept
 {
-namespace intel_x64
-{
-namespace ept
-{
+
+namespace ept = eapis::intel_x64::ept;
 
 constexpr const uintptr_t mock_pml4_hpa = 0x000ABCD000000000ULL;
 constexpr const uintptr_t mock_pdpt_hpa = 0x0000000ABCD00000ULL;
@@ -38,264 +38,130 @@ constexpr const uintptr_t mock_pd_hpa = 0x0000000123400000ULL;
 constexpr const uintptr_t mock_pt_hpa = 0x0000000DCBA00000ULL;
 constexpr const uintptr_t mock_page_hpa = 0x000000000F00D000ULL;
 
-constexpr const uint64_t mock_pml4e_offset = 0xFF8;
-constexpr const uint64_t mock_pdpte_offset = 0xFF8;
-constexpr const uint64_t mock_pde_offset = 0xFF8;
-constexpr const uint64_t mock_pte_offset = 0xFF8;
-constexpr const uint64_t mock_page_offset = 0xA55A;
-
 constexpr const uintptr_t mock_1g_hpa = 0xFFFFC0000000ULL;
 constexpr const uintptr_t mock_2m_hpa = 0xFFFFFFE00000ULL;
 constexpr const uintptr_t mock_4k_hpa = 0xFFFFFFFFF000ULL;
 
-// The following gpa is mapped into all mocked memory maps
 constexpr const uintptr_t g_mapped_gpa = 0x0000FFFFFFFFF000ULL;
-
-// The following gpa is not mapped by any entries in any mocked memory maps
 constexpr const uintptr_t g_unmapped_gpa = 0x0000000000000000ULL;
 
-std::map<void *, uintptr_t> g_mock_mem;
 
-static volatile uintptr_t g_next_phys_addr = 0x00000000F00D0000;
-
-uintptr_t
-mock_virtptr_to_physint(void *gva)
+class ept_test_support
 {
-    if (g_mock_mem.count(gva)) {
-        return g_mock_mem.at(gva);
-    }
 
-    g_next_phys_addr += 0x1000;
-    g_mock_mem[gva] = g_next_phys_addr;
-    return g_next_phys_addr;
-}
+public:
 
-void *
-mock_virtptr_to_physptr(void *gva)
-{
-    return reinterpret_cast<void *>(mock_virtptr_to_physint(gva));
-}
+    /// Constructor
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @param mocks HippoMocks object for mocked memory manager functions
+    ///
+    ept_test_support(HippoMocks::MockRepository &mocks);
 
-uintptr_t
-mock_virtint_to_physint(uintptr_t gva)
-{
-    return mock_virtptr_to_physint(reinterpret_cast<void *>(gva));
-}
+    /// Destructor
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    ~ept_test_support() = default;
 
-void *
-mock_virtint_to_physptr(uintptr_t gva)
-{
-    return reinterpret_cast<void *>(mock_virtint_to_physint(gva));
-}
+    /// Add a mock host-virtual to host-physical mapping to the mock memory
+    /// manager used by this test support object
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @param hva Host-virtual address to map from
+    /// @param hpa Host-physical address to map to
+    ///
+    void add_mock_mapping(ept::hva_t hva, ept::hpa_t hpa);
 
-void *
-mock_physint_to_virtptr(uintptr_t gpa)
-{
-    for (auto const &x : g_mock_mem) {
-        if (x.second == gpa) {
-            return x.first;
-        }
-    }
-    std::stringstream msg;
-    msg << "invalid test guest physical address: " << std::hex << "0x" << gpa;
-    throw std::logic_error(msg.str().c_str());
-}
+    /// Set up the given ept memory map object with a pml4 table that contains
+    /// no entries
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @param map The ept memory map to create mocked ept page tables for
+    ///
+    void setup_mock_empty_pml4(ept::memory_map &map);
 
-void *
-mock_physptr_to_virtptr(void *gpa)
-{
-    return mock_physint_to_virtptr(reinterpret_cast<uintptr_t>(gpa));
-}
+    /// Set up the given ept memory map object with a single 1GB page mapping,
+    /// a single unamapped 1GB page table entry, and invalid EPT entries for
+    /// all other page table entries in the memory map
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @param map The ept memory map to create mocked ept page tables for
+    ///
+    void setup_mock_1g_page(ept::memory_map &map);
 
-uintptr_t
-mock_physint_to_virtint(uintptr_t gpa)
-{
-    return reinterpret_cast<uintptr_t>(mock_physint_to_virtptr(gpa));
-}
+    /// Set up the given ept memory map object with a single 2MB page mapping,
+    /// a single unamapped 2MB page table entry, and invalid EPT entries for
+    /// all other page table entries in the memory map
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @param map The ept memory map to create mocked ept page tables for
+    ///
+    void setup_mock_2m_page(ept::memory_map &map);
 
-uintptr_t
-mock_physptr_to_virtint(void *gpa)
-{
-    return reinterpret_cast<uintptr_t>(mock_physptr_to_virtptr(gpa));
-}
+    /// Set up the given ept memory map object with a single 4KB page mapping,
+    /// a single unamapped 4KB page table entry, and invalid EPT entries for
+    /// all other page table entries in the memory map
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @param map The ept memory map to create mocked ept page tables for
+    ///
+    void setup_mock_4k_page(ept::memory_map &map);
 
-auto
-setup_mock_ept_memory_manager(MockRepository &mocks)
-{
-    auto mm = mocks.Mock<bfvmm::memory_manager>();
-    mocks.OnCallFunc(bfvmm::memory_manager::instance).Return(mm);
+    /// Remove all mock mappings from the givem ept memory map, and reset all
+    /// mock page table entries to an invalid value.
+    ///
+    /// NOTE: Users of the ept_test_support class must call this function
+    /// before destruction of any associated ept memory objects that have been
+    /// manipulated by this class.
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @param map The ept memory map to reset
+    ///
+    void reset(ept::memory_map &map);
 
-    mocks.OnCall(mm, bfvmm::memory_manager::virtptr_to_physint).Do([&](auto gva) { return mock_virtptr_to_physint(gva); });
-    mocks.OnCall(mm, bfvmm::memory_manager::virtint_to_physint).Do([&](auto gva) { return mock_virtint_to_physint(gva); });
-    mocks.OnCall(mm, bfvmm::memory_manager::virtptr_to_physptr).Do([&](auto gva) { return mock_virtptr_to_physptr(gva); });
-    mocks.OnCall(mm, bfvmm::memory_manager::virtint_to_physptr).Do([&](auto gva) { return mock_virtint_to_physptr(gva); });
-    mocks.OnCall(mm, bfvmm::memory_manager::physint_to_virtptr).Do([&](auto gpa) { return mock_physint_to_virtptr(gpa); });
-    mocks.OnCall(mm, bfvmm::memory_manager::physint_to_virtint).Do([&](auto gpa) { return mock_physint_to_virtint(gpa); });
-    mocks.OnCall(mm, bfvmm::memory_manager::physptr_to_virtptr).Do([&](auto gpa) { return mock_physptr_to_virtptr(gpa); });
-    mocks.OnCall(mm, bfvmm::memory_manager::physptr_to_virtint).Do([&](auto gpa) { return mock_physptr_to_virtint(gpa); });
-    return mm;
-}
+private:
 
-void
-allocate_mock_empty_pml4(ept::memory_map &map)
-{
-    void *pml4 = operator new (ept::page_table::size_bytes);
-    map.m_pml4_hva = reinterpret_cast<uintptr_t>(pml4);
-    memset(pml4, 0, ept::page_table::size_bytes);
-    g_mock_mem[pml4] = mock_pml4_hpa;
-}
+    uintptr_t mock_virtptr_to_physint(void *gva);
+    void *mock_virtptr_to_physptr(void *gva);
+    uintptr_t mock_virtint_to_physint(uintptr_t gva);
+    void *mock_virtint_to_physptr(uintptr_t gva);
+    void *mock_physint_to_virtptr(uintptr_t gpa);
+    uintptr_t mock_physint_to_virtint(uintptr_t gpa);
+    void *mock_physptr_to_virtptr(void *gpa);
+    uintptr_t mock_physptr_to_virtint(void *gpa);
 
-void
-allocate_mock_1g_page(ept::memory_map &map)
-{
-    void *pml4 = operator new (ept::page_table::size_bytes);
-    void *pdpt = operator new (ept::page_table::size_bytes);
-    void *page = operator new (ept::pte::page_size_bytes);
-    memset(pml4, 0xFF, ept::page_table::size_bytes);
-    memset(pdpt, 0xFF, ept::page_table::size_bytes);
-    memset(page, 0xFF, ept::pte::page_size_bytes);
+private:
 
-    // Setup mock page tables with one empty entry and one 1G page frame
-    map.m_pml4_hva = reinterpret_cast<uintptr_t>(pml4);
-    epte_t *pml4e = static_cast<epte_t *>(pml4);
-    epte::clear(*pml4e);
-    pml4e += (ept::page_table::num_entries - 1);
-    epte::clear(*pml4e);
-    epte::read_access::enable(*pml4e);
-    epte::write_access::enable(*pml4e);
-    epte::set_hpa(*pml4e, mock_pdpt_hpa & epte::phys_addr_bits::mask);
+    bfvmm::memory_manager *m_mock_mm;
 
-    epte_t *pdpte = static_cast<epte_t *>(pdpt);
-    epte::clear(*pdpte);
-    pdpte += (ept::page_table::num_entries - 1);
-    epte::clear(*pdpte);
-    epte::read_access::enable(*pdpte);
-    epte::write_access::enable(*pdpte);
-    epte::entry_type::enable(*pdpte);
-    epte::set_hpa(*pdpte, mock_page_hpa);
+    std::map<ept::hva_t, ept::hpa_t> m_mock_mem;
+    volatile uintptr_t m_next_phys_addr = 0x00000000F00D0000;
+    ept::hva_t m_saved_pml4_hva = 0;
 
-    // Setup the mock memory manager's virt->phys mappings for the
-    // page table entries allocated above
-    g_mock_mem[pml4] = mock_pml4_hpa;
-    g_mock_mem[pdpt] = mock_pdpt_hpa;
-    g_mock_mem[page] = mock_page_hpa;
-}
+    std::unique_ptr<ept::epte_t[]> m_pml4 = std::make_unique<ept::epte_t[]>(ept::page_table::num_entries);
+    std::unique_ptr<ept::epte_t[]> m_pdpt = std::make_unique<ept::epte_t[]>(ept::page_table::num_entries);
+    std::unique_ptr<ept::epte_t[]> m_pd = std::make_unique<ept::epte_t[]>(ept::page_table::num_entries);
+    std::unique_ptr<ept::epte_t[]> m_pt = std::make_unique<ept::epte_t[]>(ept::page_table::num_entries);
+    std::unique_ptr<gsl::byte[]> m_page = std::make_unique<gsl::byte[]>(ept::page_size_4k);
 
-void
-allocate_mock_2m_page(ept::memory_map &map)
-{
-    void *pml4 = operator new (ept::page_table::size_bytes);
-    void *pdpt = operator new (ept::page_table::size_bytes);
-    void *pd = operator new (ept::page_table::size_bytes);
-    void *page = operator new (ept::pte::page_size_bytes);
-    memset(pml4, 0xFF, ept::page_table::size_bytes);
-    memset(pdpt, 0xFF, ept::page_table::size_bytes);
-    memset(pd, 0xFF, ept::page_table::size_bytes);
-    memset(page, 0xFF, ept::pte::page_size_bytes);
-
-    // Setup mock page tables with one empty entry and one 2MB page frame
-    map.m_pml4_hva = reinterpret_cast<uintptr_t>(pml4);
-    epte_t *pml4e = static_cast<epte_t *>(pml4);
-    epte::clear(*pml4e);
-    pml4e += (ept::page_table::num_entries - 1);
-    epte::clear(*pml4e);
-    epte::read_access::enable(*pml4e);
-    epte::write_access::enable(*pml4e);
-    epte::set_hpa(*pml4e, mock_pdpt_hpa & epte::phys_addr_bits::mask);
-
-    epte_t *pdpte = static_cast<epte_t *>(pdpt);
-    epte::clear(*pdpte);
-    pdpte += (ept::page_table::num_entries - 1);
-    epte::clear(*pdpte);
-    epte::read_access::enable(*pdpte);
-    epte::write_access::enable(*pdpte);
-    epte::set_hpa(*pdpte, mock_pd_hpa & epte::phys_addr_bits::mask);
-
-    epte_t *pde = static_cast<epte_t *>(pd);
-    epte::clear(*pde);
-    pde += (ept::page_table::num_entries - 1);
-    epte::clear(*pde);
-    epte::read_access::enable(*pde);
-    epte::write_access::enable(*pde);
-    epte::entry_type::enable(*pde);
-    epte::set_hpa(*pde, mock_page_hpa);
-
-    // Setup the mock memory manager's virt->phys mappings for the
-    // page table entries allocated above
-    g_mock_mem[pml4] = mock_pml4_hpa;
-    g_mock_mem[pdpt] = mock_pdpt_hpa;
-    g_mock_mem[pd] = mock_pd_hpa;
-    g_mock_mem[page] = mock_page_hpa;
-}
-
-void
-allocate_mock_4k_page(ept::memory_map &map)
-{
-    void *pml4 = operator new (ept::page_table::size_bytes);
-    void *pdpt = operator new (ept::page_table::size_bytes);
-    void *pd = operator new (ept::page_table::size_bytes);
-    void *pt = operator new (ept::page_table::size_bytes);
-    void *page = operator new (ept::pte::page_size_bytes);
-    memset(pml4, 0xFF, ept::page_table::size_bytes);
-    memset(pdpt, 0xFF, ept::page_table::size_bytes);
-    memset(pd, 0xFF, ept::page_table::size_bytes);
-    memset(pt, 0xFF, ept::page_table::size_bytes);
-    memset(page, 0xFF, ept::pte::page_size_bytes);
-
-    // Setup mock page tables with one empty entry and one 4KB page frame
-    map.m_pml4_hva = reinterpret_cast<uintptr_t>(pml4);
-    epte_t *pml4e = static_cast<epte_t *>(pml4);
-    epte::clear(*pml4e);
-    pml4e += (ept::page_table::num_entries - 1);
-    epte::clear(*pml4e);
-    epte::read_access::enable(*pml4e);
-    epte::write_access::enable(*pml4e);
-    epte::set_hpa(*pml4e, mock_pdpt_hpa & epte::phys_addr_bits::mask);
-
-    epte_t *pdpte = static_cast<epte_t *>(pdpt);
-    epte::clear(*pdpte);
-    pdpte += (ept::page_table::num_entries - 1);
-    epte::clear(*pdpte);
-    epte::read_access::enable(*pdpte);
-    epte::write_access::enable(*pdpte);
-    epte::set_hpa(*pdpte, mock_pd_hpa & epte::phys_addr_bits::mask);
-
-    epte_t *pde = static_cast<epte_t *>(pd);
-    epte::clear(*pde);
-    pde += (ept::page_table::num_entries - 1);
-    epte::clear(*pde);
-    epte::read_access::enable(*pde);
-    epte::write_access::enable(*pde);
-    epte::set_hpa(*pde, mock_pt_hpa & epte::phys_addr_bits::mask);
-
-    epte_t *pte = static_cast<epte_t *>(pt);
-    epte::clear(*pte);
-    pte += (ept::page_table::num_entries - 1);
-    epte::clear(*pte);
-    epte::read_access::enable(*pte);
-    epte::write_access::enable(*pte);
-    epte::entry_type::enable(*pte);
-    epte::set_hpa(*pte, mock_page_hpa);
-
-    // Setup the mock memory manager's virt->phys mappings for the
-    // page table entries allocated above
-    g_mock_mem[pml4] = mock_pml4_hpa;
-    g_mock_mem[pdpt] = mock_pdpt_hpa;
-    g_mock_mem[pd] = mock_pd_hpa;
-    g_mock_mem[pt] = mock_pt_hpa;
-    g_mock_mem[page] = mock_page_hpa;
-}
-
-void
-free_mock_tables()
-{
-    for (auto const &item : g_mock_mem) {
-        operator delete (item.first);
-    }
-    g_mock_mem.clear();
-    g_next_phys_addr = 0xF00D0000;
-}
+};
 
 }
-}
-}
+
+#endif

--- a/bfvmm/tests/hve/arch/intel_x64/ept/test_helpers.cpp
+++ b/bfvmm/tests/hve/arch/intel_x64/ept/test_helpers.cpp
@@ -24,18 +24,18 @@
 
 namespace eptp = intel_x64::vmcs::ept_pointer;
 
-namespace eapis
+namespace test_ept
 {
-namespace intel_x64
-{
-namespace ept
-{
+
+extern "C" uint64_t unsafe_write_cstr(const char *cstr, size_t len)
+{ bfignored(cstr); bfignored(len); return 0; }
+
 
 TEST_CASE("ept::eptp")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
 
     uint64_t expected{0ULL};
     expected = eptp::memory_type::set(expected, eptp::memory_type::write_back);
@@ -49,188 +49,186 @@ TEST_CASE("ept::eptp")
 TEST_CASE("ept::map_1g")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
-    uintptr_t gpa = g_unmapped_gpa;
-    uintptr_t hpa = mock_1g_hpa;
-    epte_t result_entry{0ULL};
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t hpa = test_ept::mock_1g_hpa;
+    ept::epte_t result_entry{0ULL};
 
     ept::map_1g(*mem_map, gpa, hpa);
     CHECK_THROWS(ept::map_1g(*mem_map, gpa, hpa));
     result_entry = mem_map->gpa_to_epte(gpa);
-    CHECK(epte::hpa(result_entry) == hpa);
+    CHECK(ept::epte::hpa(result_entry) == hpa);
 }
 
 TEST_CASE("ept::map_1g with attributes")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
-    uintptr_t gpa = g_unmapped_gpa;
-    uintptr_t hpa = mock_1g_hpa;
-    ept::memory_attr_t mtype = epte::memory_attr::wb_rw;
-    epte_t result_entry{0ULL};
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t hpa = test_ept::mock_1g_hpa;
+    ept::memory_attr_t mtype = ept::epte::memory_attr::wb_rw;
+    ept::epte_t result_entry{0ULL};
 
     ept::map_1g(*mem_map, gpa, hpa, mtype);
     CHECK_THROWS(ept::map_1g(*mem_map, gpa, hpa, mtype));
     result_entry = mem_map->gpa_to_epte(gpa);
-    CHECK(epte::hpa(result_entry) == hpa);
+    CHECK(ept::epte::hpa(result_entry) == hpa);
 }
 
 TEST_CASE("ept::identity_map_1g")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
-    uintptr_t gpa = g_unmapped_gpa;
-    ept::memory_attr_t mtype = epte::memory_attr::wb_rw;
-    epte_t result_entry{0ULL};
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    ept::memory_attr_t mtype = ept::epte::memory_attr::wb_rw;
+    ept::epte_t result_entry{0ULL};
 
     ept::identity_map_1g(*mem_map, gpa);
     CHECK_THROWS(ept::identity_map_1g(*mem_map, gpa));
     result_entry = mem_map->gpa_to_epte(gpa);
-    CHECK(epte::hpa(result_entry) == gpa);
+    CHECK(ept::epte::hpa(result_entry) == gpa);
 }
 
 TEST_CASE("ept::identity_map_1g with attributes")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
-    uintptr_t gpa = g_unmapped_gpa;
-    ept::memory_attr_t mtype = epte::memory_attr::wb_rw;
-    epte_t result_entry{0ULL};
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    ept::memory_attr_t mtype = ept::epte::memory_attr::wb_rw;
+    ept::epte_t result_entry{0ULL};
 
     ept::identity_map_1g(*mem_map, gpa, mtype);
     CHECK_THROWS(ept::identity_map_1g(*mem_map, gpa));
     result_entry = mem_map->gpa_to_epte(gpa);
-    CHECK(epte::hpa(result_entry) == gpa);
+    CHECK(ept::epte::hpa(result_entry) == gpa);
 }
 
 TEST_CASE("ept::map_2m")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
-    uintptr_t gpa = g_unmapped_gpa;
-    uintptr_t hpa = mock_2m_hpa;
-    epte_t result_entry{0ULL};
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t hpa = test_ept::mock_2m_hpa;
+    ept::epte_t result_entry{0ULL};
 
     ept::map_2m(*mem_map, gpa, hpa);
     CHECK_THROWS(ept::map_2m(*mem_map, gpa, hpa));
     result_entry = mem_map->gpa_to_epte(gpa);
-    CHECK(epte::hpa(result_entry) == hpa);
+    CHECK(ept::epte::hpa(result_entry) == hpa);
 }
 
 TEST_CASE("ept::map_2m with attributes")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
-    uintptr_t gpa = g_unmapped_gpa;
-    uintptr_t hpa = mock_2m_hpa;
-    ept::memory_attr_t mtype = epte::memory_attr::wb_rw;
-    epte_t result_entry{0ULL};
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t hpa = test_ept::mock_2m_hpa;
+    ept::memory_attr_t mtype = ept::epte::memory_attr::wb_rw;
+    ept::epte_t result_entry{0ULL};
 
     ept::map_2m(*mem_map, gpa, hpa, mtype);
     CHECK_THROWS(ept::map_2m(*mem_map, gpa, hpa, mtype));
     result_entry = mem_map->gpa_to_epte(gpa);
-    CHECK(epte::hpa(result_entry) == hpa);
+    CHECK(ept::epte::hpa(result_entry) == hpa);
 }
 
 TEST_CASE("ept::identity_map_2m")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
-    uintptr_t gpa = g_unmapped_gpa;
-    ept::memory_attr_t mtype = epte::memory_attr::wb_rw;
-    epte_t result_entry{0ULL};
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    ept::memory_attr_t mtype = ept::epte::memory_attr::wb_rw;
+    ept::epte_t result_entry{0ULL};
 
     ept::identity_map_2m(*mem_map, gpa);
     CHECK_THROWS(ept::identity_map_2m(*mem_map, gpa));
     result_entry = mem_map->gpa_to_epte(gpa);
-    CHECK(epte::hpa(result_entry) == gpa);
+    CHECK(ept::epte::hpa(result_entry) == gpa);
 }
 
 TEST_CASE("ept::identity_map_2m with attributes")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
-    uintptr_t gpa = g_unmapped_gpa;
-    ept::memory_attr_t mtype = epte::memory_attr::wb_rw;
-    epte_t result_entry{0ULL};
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    ept::memory_attr_t mtype = ept::epte::memory_attr::wb_rw;
+    ept::epte_t result_entry{0ULL};
 
     ept::identity_map_2m(*mem_map, gpa, mtype);
     CHECK_THROWS(ept::identity_map_2m(*mem_map, gpa));
     result_entry = mem_map->gpa_to_epte(gpa);
-    CHECK(epte::hpa(result_entry) == gpa);
+    CHECK(ept::epte::hpa(result_entry) == gpa);
 }
 
 TEST_CASE("ept::map_4k")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
-    uintptr_t gpa = g_unmapped_gpa;
-    uintptr_t hpa = mock_4k_hpa;
-    epte_t result_entry{0ULL};
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t hpa = test_ept::mock_4k_hpa;
+    ept::epte_t result_entry{0ULL};
 
     ept::map_4k(*mem_map, gpa, hpa);
     CHECK_THROWS(ept::map_4k(*mem_map, gpa, hpa));
     result_entry = mem_map->gpa_to_epte(gpa);
-    CHECK(epte::hpa(result_entry) == hpa);
+    CHECK(ept::epte::hpa(result_entry) == hpa);
 }
 
 TEST_CASE("ept::map_4k with attributes")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
-    uintptr_t gpa = g_unmapped_gpa;
-    uintptr_t hpa = mock_4k_hpa;
-    ept::memory_attr_t mtype = epte::memory_attr::wb_rw;
-    epte_t result_entry{0ULL};
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t hpa = test_ept::mock_4k_hpa;
+    ept::memory_attr_t mtype = ept::epte::memory_attr::wb_rw;
+    ept::epte_t result_entry{0ULL};
 
     ept::map_4k(*mem_map, gpa, hpa, mtype);
     CHECK_THROWS(ept::map_4k(*mem_map, gpa, hpa, mtype));
     result_entry = mem_map->gpa_to_epte(gpa);
-    CHECK(epte::hpa(result_entry) == hpa);
+    CHECK(ept::epte::hpa(result_entry) == hpa);
 }
 
 TEST_CASE("ept::identity_map_4k")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
-    uintptr_t gpa = g_unmapped_gpa;
-    ept::memory_attr_t mtype = epte::memory_attr::wb_rw;
-    epte_t result_entry{0ULL};
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    ept::memory_attr_t mtype = ept::epte::memory_attr::wb_rw;
+    ept::epte_t result_entry{0ULL};
 
     ept::identity_map_4k(*mem_map, gpa);
     CHECK_THROWS(ept::identity_map_4k(*mem_map, gpa));
     result_entry = mem_map->gpa_to_epte(gpa);
-    CHECK(epte::hpa(result_entry) == gpa);
+    CHECK(ept::epte::hpa(result_entry) == gpa);
 }
 
 TEST_CASE("ept::identity_map_4k with attributes")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
-    uintptr_t gpa = g_unmapped_gpa;
-    ept::memory_attr_t mtype = epte::memory_attr::wb_rw;
-    epte_t result_entry{0ULL};
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    ept::memory_attr_t mtype = ept::epte::memory_attr::wb_rw;
+    ept::epte_t result_entry{0ULL};
 
     ept::identity_map_4k(*mem_map, gpa, mtype);
     CHECK_THROWS(ept::identity_map_4k(*mem_map, gpa));
     result_entry = mem_map->gpa_to_epte(gpa);
-    CHECK(epte::hpa(result_entry) == gpa);
+    CHECK(ept::epte::hpa(result_entry) == gpa);
 }
 
-}
-}
 }
 
 #endif

--- a/bfvmm/tests/hve/arch/intel_x64/ept/test_memory_map.cpp
+++ b/bfvmm/tests/hve/arch/intel_x64/ept/test_memory_map.cpp
@@ -21,50 +21,44 @@
 
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-namespace eapis
+namespace test_ept
 {
-namespace intel_x64
-{
-namespace ept
-{
+
+extern "C" uint64_t unsafe_write_cstr(const char *cstr, size_t len)
+{ bfignored(cstr); bfignored(len); return 0; }
+
+namespace ept = eapis::intel_x64::ept;
 
 TEST_CASE("memory_map::memory_map")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
 
     CHECK(mem_map);
     CHECK(mem_map->m_pml4_hva != 0ULL);
 }
 
-TEST_CASE("memory_map::~memory_map")
-{
-    MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
-    delete mem_map;
-}
-
 TEST_CASE("memory_map::map")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
     uintptr_t gpa{0ULL};
     uintptr_t hpa{0ULL};
     uint64_t size{0ULL};
-    epte_t entry{0ULL};
-    epte_t expected_entry{0ULL};
-    epte::entry_type::enable(expected_entry);
-    epte::read_access::enable(expected_entry);
-    epte::write_access::enable(expected_entry);
-    epte::memory_type::set(expected_entry, epte::memory_type::wb);
+    ept::epte_t expected_entry{0ULL};
+    ept::epte_t entry{0ULL};
+
+    ept::epte::entry_type::enable(expected_entry);
+    ept::epte::read_access::enable(expected_entry);
+    ept::epte::write_access::enable(expected_entry);
+    ept::epte::memory_type::set(expected_entry, ept::epte::memory_type::wb);
 
     gpa = g_unmapped_gpa;
     hpa = mock_1g_hpa;
     size = ept::pdpte::page_size_bytes;
-    epte::set_hpa(expected_entry, hpa);
+    ept::epte::set_hpa(expected_entry, hpa);
     entry = mem_map->map(gpa, hpa, size);
     CHECK(entry == expected_entry);
     CHECK_THROWS(mem_map->map(gpa, hpa, size));
@@ -73,7 +67,7 @@ TEST_CASE("memory_map::map")
     gpa += 0x10000000000ULL;
     hpa = mock_2m_hpa;
     size = ept::pde::page_size_bytes;
-    epte::set_hpa(expected_entry, hpa);
+    ept::epte::set_hpa(expected_entry, hpa);
     entry = mem_map->map(gpa, hpa, size);
     CHECK(entry == expected_entry);
     CHECK_THROWS(mem_map->map(gpa, hpa, size));
@@ -82,7 +76,7 @@ TEST_CASE("memory_map::map")
     gpa += 0x10000000000ULL;
     hpa = mock_4k_hpa;
     size = ept::pte::page_size_bytes;
-    epte::set_hpa(expected_entry, hpa);
+    ept::epte::set_hpa(expected_entry, hpa);
     entry = mem_map->map(gpa, hpa, size);
     CHECK(entry == expected_entry);
     CHECK_THROWS(mem_map->map(gpa, hpa, size));
@@ -103,16 +97,16 @@ TEST_CASE("memory_map::map")
 TEST_CASE("memory_map::unmap")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
     uintptr_t gpa{0ULL};
     uintptr_t hpa{0ULL};
     uint64_t size{0ULL};
-    epte_t entry{0ULL};
+    ept::epte_t entry{0ULL};
 
     gpa = g_mapped_gpa;
     hpa = mock_1g_hpa;
-    g_mock_mem[reinterpret_cast<void *>(gpa)] = hpa;
+    mock_ept->add_mock_mapping(gpa, hpa);
     size = ept::pdpte::page_size_bytes;
     entry = mem_map->map(gpa, hpa, size);
     CHECK(entry != 0ULL);
@@ -120,50 +114,47 @@ TEST_CASE("memory_map::unmap")
     mem_map->unmap(gpa);
     CHECK_THROWS(mem_map->gpa_to_epte(gpa));
     CHECK_THROWS(mem_map->unmap(gpa));
-
-    g_mock_mem.clear();
 }
 
 TEST_CASE("memory_map::gpa_to_epte")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    // auto old_pml4 = mem_map->m_pml4_hva;
     mem_map->m_pml4_hpa = mock_pml4_hpa;
-    epte_t result{0ULL};
+    ept::epte_t result{0ULL};
 
-    allocate_mock_empty_pml4(*mem_map);
+    mock_ept->setup_mock_empty_pml4(*mem_map);
     CHECK_THROWS(mem_map->gpa_to_epte(g_mapped_gpa));
     CHECK_THROWS(mem_map->gpa_to_epte(g_unmapped_gpa));
-    free_mock_tables();
 
-    allocate_mock_1g_page(*mem_map);
+    mock_ept->setup_mock_1g_page(*mem_map);
     CHECK_THROWS(mem_map->gpa_to_epte(g_unmapped_gpa));
     result = mem_map->gpa_to_epte(g_mapped_gpa);
-    CHECK(epte::hpa(result) == mock_page_hpa);
-    CHECK(epte::is_leaf_entry(result));
-    free_mock_tables();
+    CHECK(ept::epte::hpa(result) == mock_page_hpa);
+    CHECK(ept::epte::is_leaf_entry(result));
 
-    allocate_mock_2m_page(*mem_map);
+    mock_ept->setup_mock_2m_page(*mem_map);
     CHECK_THROWS(mem_map->gpa_to_epte(g_unmapped_gpa));
     result = mem_map->gpa_to_epte(g_mapped_gpa);
-    CHECK(epte::hpa(result) == mock_page_hpa);
-    CHECK(epte::is_leaf_entry(result));
-    free_mock_tables();
+    CHECK(ept::epte::hpa(result) == mock_page_hpa);
+    CHECK(ept::epte::is_leaf_entry(result));
 
-    allocate_mock_4k_page(*mem_map);
+    mock_ept->setup_mock_4k_page(*mem_map);
     CHECK_THROWS(mem_map->gpa_to_epte(g_unmapped_gpa));
     result = mem_map->gpa_to_epte(g_mapped_gpa);
-    CHECK(epte::hpa(result) == mock_page_hpa);
-    CHECK(epte::is_leaf_entry(result));
-    free_mock_tables();
+    CHECK(ept::epte::hpa(result) == mock_page_hpa);
+    CHECK(ept::epte::is_leaf_entry(result));
+
+    mock_ept->reset(*mem_map);
 }
 
 TEST_CASE("memory_map::hpa")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
 
     CHECK(mem_map->hpa() == mem_map->m_pml4_hpa);
 }
@@ -171,30 +162,30 @@ TEST_CASE("memory_map::hpa")
 TEST_CASE("memory_map::allocate_page_table")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
 
-    epte_t entry{0ULL};
+    ept::epte_t entry{0ULL};
     mem_map->allocate_page_table(entry);
-    CHECK(epte::read_access::is_enabled(entry));
-    CHECK(epte::write_access::is_enabled(entry));
-    CHECK(epte::execute_access::is_enabled(entry));
-    CHECK(epte::memory_type::get(entry) == epte::memory_type::wb);
-    CHECK(epte::hpa(entry));
+    CHECK(ept::epte::read_access::is_enabled(entry));
+    CHECK(ept::epte::write_access::is_enabled(entry));
+    CHECK(ept::epte::execute_access::is_enabled(entry));
+    CHECK(ept::epte::memory_type::get(entry) == ept::epte::memory_type::wb);
+    CHECK(ept::epte::hpa(entry));
 }
 
 TEST_CASE("memory_map::free_page_table")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
+    auto mock_ept = new ept_test_support(mocks);
     auto mem_map = new ept::memory_map();
-    epte_t entry{0ULL};
+    ept::epte_t entry{0ULL};
     mem_map->allocate_page_table(entry);
-    CHECK(epte::hpa(entry));
-    epte::read_access::enable(entry);
-    epte::write_access::enable(entry);
-    epte::ignore_pat::enable(entry);
-    epte::suppress_ve::enable(entry);
+    CHECK(ept::epte::hpa(entry));
+    ept::epte::read_access::enable(entry);
+    ept::epte::write_access::enable(entry);
+    ept::epte::ignore_pat::enable(entry);
+    ept::epte::suppress_ve::enable(entry);
 
     mem_map->free_page_table(entry);
     CHECK(entry == 0ULL);
@@ -203,18 +194,18 @@ TEST_CASE("memory_map::free_page_table")
 TEST_CASE("memory_map::map_entry_to_page_frame")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
     uintptr_t test_hpa = 0x0000000ABCDEF0000ULL;
 
-    epte_t expected_entry{0ULL};
-    epte::set_hpa(expected_entry, test_hpa);
-    epte::read_access::enable(expected_entry);
-    epte::write_access::enable(expected_entry);
-    epte::memory_type::set(expected_entry, epte::memory_type::wb);
-    epte::entry_type::enable(expected_entry);
+    ept::epte_t expected_entry{0ULL};
+    ept::epte::set_hpa(expected_entry, test_hpa);
+    ept::epte::read_access::enable(expected_entry);
+    ept::epte::write_access::enable(expected_entry);
+    ept::epte::memory_type::set(expected_entry, ept::epte::memory_type::wb);
+    ept::epte::entry_type::enable(expected_entry);
 
-    epte_t entry{0ULL};
+    ept::epte_t entry{0ULL};
     mem_map->map_entry_to_page_frame(entry, test_hpa);
     CHECK(entry == expected_entry);
 }
@@ -222,294 +213,270 @@ TEST_CASE("memory_map::map_entry_to_page_frame")
 TEST_CASE("memory_map::gpa_to_pml4e")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
-    epte_t pml4e{0ULL};
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    ept::epte_t pml4e{0ULL};
     mem_map->m_pml4_hpa = mock_pml4_hpa;
 
-    allocate_mock_empty_pml4(*mem_map);
+    mock_ept->setup_mock_empty_pml4(*mem_map);
     pml4e = mem_map->gpa_to_pml4e(g_mapped_gpa);
     CHECK(pml4e == 0ULL);
-    free_mock_tables();
 
-    allocate_mock_4k_page(*mem_map);
+    mock_ept->setup_mock_4k_page(*mem_map);
     pml4e = mem_map->gpa_to_pml4e(g_mapped_gpa);
-    CHECK(epte::read_access::is_enabled(pml4e));
-    CHECK(epte::write_access::is_enabled(pml4e));
-    CHECK(epte::execute_access::is_disabled(pml4e));
-    CHECK(epte::hpa(pml4e) == mock_pdpt_hpa);
-    free_mock_tables();
+    CHECK(ept::epte::read_access::is_enabled(pml4e));
+    CHECK(ept::epte::write_access::is_enabled(pml4e));
+    CHECK(ept::epte::execute_access::is_disabled(pml4e));
+    CHECK(ept::epte::hpa(pml4e) == mock_pdpt_hpa);
+
+    mock_ept->reset(*mem_map);
 }
 
 TEST_CASE("memory_map::gpa_to_pdpte")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
-    epte_t pml4e{0ULL};
-    epte_t pdpte{0ULL};
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    ept::epte_t pml4e{0ULL};
+    ept::epte_t pdpte{0ULL};
     mem_map->m_pml4_hpa = mock_pml4_hpa;
 
-    allocate_mock_empty_pml4(*mem_map);
+    mock_ept->setup_mock_empty_pml4(*mem_map);
     pml4e = mem_map->gpa_to_pml4e(g_mapped_gpa);
     CHECK_THROWS(mem_map->gpa_to_pdpte(g_mapped_gpa, pml4e));
-    free_mock_tables();
 
-    allocate_mock_1g_page(*mem_map);
+    mock_ept->setup_mock_1g_page(*mem_map);
     pml4e = mem_map->gpa_to_pml4e(g_mapped_gpa);
     pdpte = mem_map->gpa_to_pdpte(g_mapped_gpa, pml4e);
-    CHECK(epte::read_access::is_enabled(pdpte));
-    CHECK(epte::write_access::is_enabled(pdpte));
-    CHECK(epte::execute_access::is_disabled(pdpte));
-    CHECK(epte::entry_type::is_enabled(pdpte));
-    CHECK(epte::hpa(pdpte) == mock_page_hpa);
-    free_mock_tables();
+    CHECK(ept::epte::read_access::is_enabled(pdpte));
+    CHECK(ept::epte::write_access::is_enabled(pdpte));
+    CHECK(ept::epte::execute_access::is_disabled(pdpte));
+    CHECK(ept::epte::entry_type::is_enabled(pdpte));
+    CHECK(ept::epte::hpa(pdpte) == mock_page_hpa);
 
-    allocate_mock_4k_page(*mem_map);
+    mock_ept->setup_mock_4k_page(*mem_map);
     pml4e = mem_map->gpa_to_pml4e(g_mapped_gpa);
     pdpte = mem_map->gpa_to_pdpte(g_mapped_gpa, pml4e);
-    CHECK(epte::read_access::is_enabled(pdpte));
-    CHECK(epte::write_access::is_enabled(pdpte));
-    CHECK(epte::execute_access::is_disabled(pdpte));
-    CHECK(epte::hpa(pdpte) == mock_pd_hpa);
-    free_mock_tables();
+    CHECK(ept::epte::read_access::is_enabled(pdpte));
+    CHECK(ept::epte::write_access::is_enabled(pdpte));
+    CHECK(ept::epte::execute_access::is_disabled(pdpte));
+    CHECK(ept::epte::hpa(pdpte) == mock_pd_hpa);
+
+    mock_ept->reset(*mem_map);
 }
 
 TEST_CASE("memory_map::gpa_to_pde")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
-    epte_t pml4e{0ULL};
-    epte_t pdpte{0ULL};
-    epte_t pde{0ULL};
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    ept::epte_t pml4e{0ULL};
+    ept::epte_t pdpte{0ULL};
+    ept::epte_t pde{0ULL};
     mem_map->m_pml4_hpa = mock_pml4_hpa;
 
-    allocate_mock_2m_page(*mem_map);
+    mock_ept->setup_mock_2m_page(*mem_map);
     pml4e = mem_map->gpa_to_pml4e(g_mapped_gpa);
     pdpte = mem_map->gpa_to_pdpte(g_mapped_gpa, pml4e);
     pde = mem_map->gpa_to_pde(g_mapped_gpa, pdpte);
-    CHECK(epte::read_access::is_enabled(pde));
-    CHECK(epte::write_access::is_enabled(pde));
-    CHECK(epte::execute_access::is_disabled(pde));
-    CHECK(epte::entry_type::is_enabled(pde));
-    CHECK(epte::hpa(pde) == mock_page_hpa);
-    free_mock_tables();
+    CHECK(ept::epte::read_access::is_enabled(pde));
+    CHECK(ept::epte::write_access::is_enabled(pde));
+    CHECK(ept::epte::execute_access::is_disabled(pde));
+    CHECK(ept::epte::entry_type::is_enabled(pde));
+    CHECK(ept::epte::hpa(pde) == mock_page_hpa);
 
-    allocate_mock_4k_page(*mem_map);
+    mock_ept->setup_mock_4k_page(*mem_map);
     pml4e = mem_map->gpa_to_pml4e(g_mapped_gpa);
     pdpte = mem_map->gpa_to_pdpte(g_mapped_gpa, pml4e);
     pde = mem_map->gpa_to_pde(g_mapped_gpa, pdpte);
-    CHECK(epte::read_access::is_enabled(pde));
-    CHECK(epte::write_access::is_enabled(pde));
-    CHECK(epte::execute_access::is_disabled(pde));
-    CHECK(epte::hpa(pde) == mock_pt_hpa);
-    free_mock_tables();
+    CHECK(ept::epte::read_access::is_enabled(pde));
+    CHECK(ept::epte::write_access::is_enabled(pde));
+    CHECK(ept::epte::execute_access::is_disabled(pde));
+    CHECK(ept::epte::hpa(pde) == mock_pt_hpa);
+
+    mock_ept->reset(*mem_map);
 }
 
 TEST_CASE("memory_map::gpa_to_pte")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
-    epte_t pml4e{0ULL};
-    epte_t pdpte{0ULL};
-    epte_t pde{0ULL};
-    epte_t pte{0ULL};
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    ept::epte_t pml4e{0ULL};
+    ept::epte_t pdpte{0ULL};
+    ept::epte_t pde{0ULL};
+    ept::epte_t pte{0ULL};
     mem_map->m_pml4_hpa = mock_pml4_hpa;
 
-    allocate_mock_4k_page(*mem_map);
+    mock_ept->setup_mock_4k_page(*mem_map);
     pml4e = mem_map->gpa_to_pml4e(g_mapped_gpa);
     pdpte = mem_map->gpa_to_pdpte(g_mapped_gpa, pml4e);
     pde = mem_map->gpa_to_pde(g_mapped_gpa, pdpte);
     pte = mem_map->gpa_to_pte(g_mapped_gpa, pde);
-    CHECK(epte::read_access::is_enabled(pte));
-    CHECK(epte::write_access::is_enabled(pte));
-    CHECK(epte::execute_access::is_disabled(pte));
-    CHECK(epte::entry_type::is_enabled(pte));
-    CHECK(epte::hpa(pte) == mock_page_hpa);
-    free_mock_tables();
-}
+    CHECK(ept::epte::read_access::is_enabled(pte));
+    CHECK(ept::epte::write_access::is_enabled(pte));
+    CHECK(ept::epte::execute_access::is_disabled(pte));
+    CHECK(ept::epte::entry_type::is_enabled(pte));
+    CHECK(ept::epte::hpa(pte) == mock_page_hpa);
 
-// TEST_CASE("memory_map::hpa_to_gpa")
-// {
-//     MockRepository mocks;
-//     auto mm = setup_mock_ept_memory_manager(mocks);
-//     auto mem_map = new ept::memory_map();
-//     mem_map->m_pml4_hpa = mock_pml4_hpa;
-//
-//     allocate_mock_empty_pml4(*mem_map);
-//     mem_map->map(0xabcd0000ULL, 0xabcd0000ULL, pte::page_size_bytes);
-//     CHECK(mem_map->hpa_to_gpa(0xabcd0000ULL) == 0xabcd0000ULL);
-//     free_mock_tables();
-//
-//     allocate_mock_4k_page(*mem_map);
-//     mem_map->map(0ULL, 0xabcd0000ULL, pte::page_size_bytes);
-//     CHECK(mem_map->hpa_to_gpa(0ULL) == 0xabcd0000ULL);
-//     free_mock_tables();
-// }
+    mock_ept->reset(*mem_map);
+}
 
 TEST_CASE("memory_map::map_pdpte_to_page")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
     mem_map->m_pml4_hpa = mock_pml4_hpa;
-    epte_t result{0ULL};
+    ept::epte_t result{0ULL};
 
-    allocate_mock_empty_pml4(*mem_map);
+    mock_ept->setup_mock_empty_pml4(*mem_map);
     result = mem_map->map_pdpte_to_page(g_unmapped_gpa, mock_page_hpa);
-    CHECK(epte::read_access::is_enabled(result));
-    CHECK(epte::write_access::is_enabled(result));
-    CHECK(epte::execute_access::is_disabled(result));
-    CHECK(epte::entry_type::is_enabled(result));
-    CHECK(epte::memory_type::get(result) == epte::memory_type::wb);
-    CHECK(epte::hpa(result) == mock_page_hpa);
-    free_mock_tables();
+    CHECK(ept::epte::read_access::is_enabled(result));
+    CHECK(ept::epte::write_access::is_enabled(result));
+    CHECK(ept::epte::execute_access::is_disabled(result));
+    CHECK(ept::epte::entry_type::is_enabled(result));
+    CHECK(ept::epte::memory_type::get(result) == ept::epte::memory_type::wb);
+    CHECK(ept::epte::hpa(result) == mock_page_hpa);
 
-    allocate_mock_1g_page(*mem_map);
+    mock_ept->setup_mock_1g_page(*mem_map);
     CHECK_THROWS(mem_map->map_pdpte_to_page(g_mapped_gpa, mock_page_hpa));
     result = mem_map->map_pdpte_to_page(g_unmapped_gpa, mock_page_hpa);
-    CHECK(epte::read_access::is_enabled(result));
-    CHECK(epte::write_access::is_enabled(result));
-    CHECK(epte::execute_access::is_disabled(result));
-    CHECK(epte::entry_type::is_enabled(result));
-    CHECK(epte::memory_type::get(result) == epte::memory_type::wb);
-    CHECK(epte::hpa(result) == mock_page_hpa);
-    free_mock_tables();
+    CHECK(ept::epte::read_access::is_enabled(result));
+    CHECK(ept::epte::write_access::is_enabled(result));
+    CHECK(ept::epte::execute_access::is_disabled(result));
+    CHECK(ept::epte::entry_type::is_enabled(result));
+    CHECK(ept::epte::memory_type::get(result) == ept::epte::memory_type::wb);
+    CHECK(ept::epte::hpa(result) == mock_page_hpa);
 
-    allocate_mock_2m_page(*mem_map);
+    mock_ept->setup_mock_2m_page(*mem_map);
     CHECK_THROWS(mem_map->map_pdpte_to_page(g_mapped_gpa, mock_page_hpa));
     result = mem_map->map_pdpte_to_page(g_unmapped_gpa, mock_page_hpa);
-    CHECK(epte::read_access::is_enabled(result));
-    CHECK(epte::write_access::is_enabled(result));
-    CHECK(epte::execute_access::is_disabled(result));
-    CHECK(epte::entry_type::is_enabled(result));
-    CHECK(epte::memory_type::get(result) == epte::memory_type::wb);
-    CHECK(epte::hpa(result) == mock_page_hpa);
-    free_mock_tables();
+    CHECK(ept::epte::read_access::is_enabled(result));
+    CHECK(ept::epte::write_access::is_enabled(result));
+    CHECK(ept::epte::execute_access::is_disabled(result));
+    CHECK(ept::epte::entry_type::is_enabled(result));
+    CHECK(ept::epte::memory_type::get(result) == ept::epte::memory_type::wb);
+    CHECK(ept::epte::hpa(result) == mock_page_hpa);
 
-    allocate_mock_4k_page(*mem_map);
+    mock_ept->setup_mock_4k_page(*mem_map);
     CHECK_THROWS(mem_map->map_pdpte_to_page(g_mapped_gpa, mock_page_hpa));
     result = mem_map->map_pdpte_to_page(g_unmapped_gpa, mock_page_hpa);
-    CHECK(epte::read_access::is_enabled(result));
-    CHECK(epte::write_access::is_enabled(result));
-    CHECK(epte::execute_access::is_disabled(result));
-    CHECK(epte::entry_type::is_enabled(result));
-    CHECK(epte::memory_type::get(result) == epte::memory_type::wb);
-    CHECK(epte::hpa(result) == mock_page_hpa);
-    free_mock_tables();
+    CHECK(ept::epte::read_access::is_enabled(result));
+    CHECK(ept::epte::write_access::is_enabled(result));
+    CHECK(ept::epte::execute_access::is_disabled(result));
+    CHECK(ept::epte::entry_type::is_enabled(result));
+    CHECK(ept::epte::memory_type::get(result) == ept::epte::memory_type::wb);
+    CHECK(ept::epte::hpa(result) == mock_page_hpa);
+
+    mock_ept->reset(*mem_map);
 }
 
 TEST_CASE("memory_map::map_pde_to_page")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
     mem_map->m_pml4_hpa = mock_pml4_hpa;
-    epte_t result{0ULL};
+    ept::epte_t result{0ULL};
 
-    allocate_mock_empty_pml4(*mem_map);
+    mock_ept->setup_mock_empty_pml4(*mem_map);
     result = mem_map->map_pde_to_page(g_unmapped_gpa, mock_page_hpa);
-    CHECK(epte::read_access::is_enabled(result));
-    CHECK(epte::write_access::is_enabled(result));
-    CHECK(epte::execute_access::is_disabled(result));
-    CHECK(epte::entry_type::is_enabled(result));
-    CHECK(epte::memory_type::get(result) == epte::memory_type::wb);
-    CHECK(epte::hpa(result) == mock_page_hpa);
-    free_mock_tables();
+    CHECK(ept::epte::read_access::is_enabled(result));
+    CHECK(ept::epte::write_access::is_enabled(result));
+    CHECK(ept::epte::execute_access::is_disabled(result));
+    CHECK(ept::epte::entry_type::is_enabled(result));
+    CHECK(ept::epte::memory_type::get(result) == ept::epte::memory_type::wb);
+    CHECK(ept::epte::hpa(result) == mock_page_hpa);
 
-    allocate_mock_1g_page(*mem_map);
+    mock_ept->setup_mock_1g_page(*mem_map);
     CHECK_THROWS(mem_map->map_pde_to_page(g_mapped_gpa, mock_page_hpa));
     result = mem_map->map_pde_to_page(g_unmapped_gpa, mock_page_hpa);
-    CHECK(epte::read_access::is_enabled(result));
-    CHECK(epte::write_access::is_enabled(result));
-    CHECK(epte::execute_access::is_disabled(result));
-    CHECK(epte::entry_type::is_enabled(result));
-    CHECK(epte::memory_type::get(result) == epte::memory_type::wb);
-    CHECK(epte::hpa(result) == mock_page_hpa);
-    free_mock_tables();
+    CHECK(ept::epte::read_access::is_enabled(result));
+    CHECK(ept::epte::write_access::is_enabled(result));
+    CHECK(ept::epte::execute_access::is_disabled(result));
+    CHECK(ept::epte::entry_type::is_enabled(result));
+    CHECK(ept::epte::memory_type::get(result) == ept::epte::memory_type::wb);
+    CHECK(ept::epte::hpa(result) == mock_page_hpa);
 
-    allocate_mock_2m_page(*mem_map);
+    mock_ept->setup_mock_2m_page(*mem_map);
     CHECK_THROWS(mem_map->map_pde_to_page(g_mapped_gpa, mock_page_hpa));
     result = mem_map->map_pde_to_page(g_unmapped_gpa, mock_page_hpa);
-    CHECK(epte::read_access::is_enabled(result));
-    CHECK(epte::write_access::is_enabled(result));
-    CHECK(epte::execute_access::is_disabled(result));
-    CHECK(epte::entry_type::is_enabled(result));
-    CHECK(epte::memory_type::get(result) == epte::memory_type::wb);
-    CHECK(epte::hpa(result) == mock_page_hpa);
-    free_mock_tables();
+    CHECK(ept::epte::read_access::is_enabled(result));
+    CHECK(ept::epte::write_access::is_enabled(result));
+    CHECK(ept::epte::execute_access::is_disabled(result));
+    CHECK(ept::epte::entry_type::is_enabled(result));
+    CHECK(ept::epte::memory_type::get(result) == ept::epte::memory_type::wb);
+    CHECK(ept::epte::hpa(result) == mock_page_hpa);
 
-    allocate_mock_4k_page(*mem_map);
+    mock_ept->setup_mock_4k_page(*mem_map);
     CHECK_THROWS(mem_map->map_pde_to_page(g_mapped_gpa, mock_page_hpa));
     result = mem_map->map_pde_to_page(g_unmapped_gpa, mock_page_hpa);
-    CHECK(epte::read_access::is_enabled(result));
-    CHECK(epte::write_access::is_enabled(result));
-    CHECK(epte::execute_access::is_disabled(result));
-    CHECK(epte::entry_type::is_enabled(result));
-    CHECK(epte::memory_type::get(result) == epte::memory_type::wb);
-    CHECK(epte::hpa(result) == mock_page_hpa);
-    free_mock_tables();
+    CHECK(ept::epte::read_access::is_enabled(result));
+    CHECK(ept::epte::write_access::is_enabled(result));
+    CHECK(ept::epte::execute_access::is_disabled(result));
+    CHECK(ept::epte::entry_type::is_enabled(result));
+    CHECK(ept::epte::memory_type::get(result) == ept::epte::memory_type::wb);
+    CHECK(ept::epte::hpa(result) == mock_page_hpa);
+
+    mock_ept->reset(*mem_map);
 }
 
 TEST_CASE("memory_map::map_pte_to_page")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
     mem_map->m_pml4_hpa = mock_pml4_hpa;
-    epte_t result{0ULL};
+    ept::epte_t result{0ULL};
 
-    allocate_mock_empty_pml4(*mem_map);
+    mock_ept->setup_mock_empty_pml4(*mem_map);
     result = mem_map->map_pte_to_page(g_unmapped_gpa, mock_page_hpa);
-    CHECK(epte::read_access::is_enabled(result));
-    CHECK(epte::write_access::is_enabled(result));
-    CHECK(epte::execute_access::is_disabled(result));
-    CHECK(epte::entry_type::is_enabled(result));
-    CHECK(epte::memory_type::get(result) == epte::memory_type::wb);
-    CHECK(epte::hpa(result) == mock_page_hpa);
-    free_mock_tables();
+    CHECK(ept::epte::read_access::is_enabled(result));
+    CHECK(ept::epte::write_access::is_enabled(result));
+    CHECK(ept::epte::execute_access::is_disabled(result));
+    CHECK(ept::epte::entry_type::is_enabled(result));
+    CHECK(ept::epte::memory_type::get(result) == ept::epte::memory_type::wb);
+    CHECK(ept::epte::hpa(result) == mock_page_hpa);
 
-    allocate_mock_1g_page(*mem_map);
+    mock_ept->setup_mock_1g_page(*mem_map);
     CHECK_THROWS(mem_map->map_pte_to_page(g_mapped_gpa, mock_page_hpa));
     result = mem_map->map_pte_to_page(g_unmapped_gpa, mock_page_hpa);
-    CHECK(epte::read_access::is_enabled(result));
-    CHECK(epte::write_access::is_enabled(result));
-    CHECK(epte::execute_access::is_disabled(result));
-    CHECK(epte::entry_type::is_enabled(result));
-    CHECK(epte::memory_type::get(result) == epte::memory_type::wb);
-    CHECK(epte::hpa(result) == mock_page_hpa);
-    free_mock_tables();
+    CHECK(ept::epte::read_access::is_enabled(result));
+    CHECK(ept::epte::write_access::is_enabled(result));
+    CHECK(ept::epte::execute_access::is_disabled(result));
+    CHECK(ept::epte::entry_type::is_enabled(result));
+    CHECK(ept::epte::memory_type::get(result) == ept::epte::memory_type::wb);
+    CHECK(ept::epte::hpa(result) == mock_page_hpa);
 
-    allocate_mock_2m_page(*mem_map);
+    mock_ept->setup_mock_2m_page(*mem_map);
     CHECK_THROWS(mem_map->map_pte_to_page(g_mapped_gpa, mock_page_hpa));
     result = mem_map->map_pte_to_page(g_unmapped_gpa, mock_page_hpa);
-    CHECK(epte::read_access::is_enabled(result));
-    CHECK(epte::write_access::is_enabled(result));
-    CHECK(epte::execute_access::is_disabled(result));
-    CHECK(epte::entry_type::is_enabled(result));
-    CHECK(epte::memory_type::get(result) == epte::memory_type::wb);
-    CHECK(epte::hpa(result) == mock_page_hpa);
-    free_mock_tables();
+    CHECK(ept::epte::read_access::is_enabled(result));
+    CHECK(ept::epte::write_access::is_enabled(result));
+    CHECK(ept::epte::execute_access::is_disabled(result));
+    CHECK(ept::epte::entry_type::is_enabled(result));
+    CHECK(ept::epte::memory_type::get(result) == ept::epte::memory_type::wb);
+    CHECK(ept::epte::hpa(result) == mock_page_hpa);
 
-    allocate_mock_4k_page(*mem_map);
+    mock_ept->setup_mock_4k_page(*mem_map);
     CHECK_THROWS(mem_map->map_pte_to_page(g_mapped_gpa, mock_page_hpa));
     result = mem_map->map_pte_to_page(g_unmapped_gpa, mock_page_hpa);
-    CHECK(epte::read_access::is_enabled(result));
-    CHECK(epte::write_access::is_enabled(result));
-    CHECK(epte::execute_access::is_disabled(result));
-    CHECK(epte::entry_type::is_enabled(result));
-    CHECK(epte::memory_type::get(result) == epte::memory_type::wb);
-    CHECK(epte::hpa(result) == mock_page_hpa);
-    free_mock_tables();
+    CHECK(ept::epte::read_access::is_enabled(result));
+    CHECK(ept::epte::write_access::is_enabled(result));
+    CHECK(ept::epte::execute_access::is_disabled(result));
+    CHECK(ept::epte::entry_type::is_enabled(result));
+    CHECK(ept::epte::memory_type::get(result) == ept::epte::memory_type::wb);
+    CHECK(ept::epte::hpa(result) == mock_page_hpa);
+
+    mock_ept->reset(*mem_map);
 }
 
 TEST_CASE("memory_map::to_mdl")
 {
     MockRepository mocks;
-    auto mm = setup_mock_ept_memory_manager(mocks);
-    auto mem_map = new ept::memory_map();
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
     mem_map->map(0xf00d0000ULL, 0ULL, ept::pte::page_size_bytes);
 
     auto result = mem_map->to_mdl();
@@ -518,11 +485,8 @@ TEST_CASE("memory_map::to_mdl")
     mem_map->map(0xbeef00000ULL, 0ULL, ept::pte::page_size_bytes);
     result = mem_map->to_mdl();
     CHECK(result.size() == 6ULL);
-    free_mock_tables();
 }
 
-}
-}
 }
 
 #endif


### PR DESCRIPTION
Got rid of numerous memory leaks, double frees, and other wanrings from
ASan in the EPT unit tests

Signed-off-by: JaredWright <jared.wright12@gmail.com>