### PR TITLE
BUG - EPT memory_map sets reserved bits

### DIFF
--- a/bfvmm/src/hve/arch/intel_x64/ept/memory_map.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/ept/memory_map.cpp
@@ -188,7 +188,6 @@ memory_map::allocate_page_table(epte_t &entry)
     epte::read_access::enable(entry);
     epte::write_access::enable(entry);
     epte::execute_access::enable(entry);
-    epte::memory_type::set(entry, epte::memory_type::wb);
     epte::set_hpa(entry, pt_hpa);
 }
 


### PR DESCRIPTION
The EPT memory map sets reserved bits in extended page table entries
that do not map a page frame (i.e. non-leaf entries). This fixes the
issue by removing the default memory_type value from the
allocate_page_table function.

Signed-off-by: JaredWright <jared.wright12@gmail.com>