### PR TITLE
Additional EPT helper functions

### DIFF
--- a/bfvmm/include/hve/arch/intel_x64/ept/helpers.h
+++ b/bfvmm/include/hve/arch/intel_x64/ept/helpers.h
@@ -24,8 +24,6 @@
 #include "intrinsics.h"
 #include "types.h"
 
-// *INDENT-OFF*
-
 namespace eapis
 {
 namespace intel_x64
@@ -34,7 +32,8 @@ namespace ept
 {
 
 /// Calculate the VMCS extended page table pointer (EPTP) field for the given
-/// memory map
+/// memory map. The returned EPTP defaults to wb memory type with accessed and
+/// dirty flags disabled.
 ///
 /// @expects
 /// @ensures
@@ -45,20 +44,25 @@ namespace ept
 ///
 uint64_t eptp(memory_map &mem_map);
 
-//--------------------------------------------------------------------------
-// 1GB pages
-//--------------------------------------------------------------------------
-
-/// Map 1GB of memory from the guest physical address to host physical address
+/// Enable EPT (and VPID if it is not enabled) using the given VMCS EPT pointer
 ///
 /// @expects
 /// @ensures
 ///
-/// @param mem_map the memory map to calculate EPTP for
-/// @param gpa the guest physical address to map from
-/// @param hpa the host physical address to map to
+/// @param eptp the VMCS EPT pointer value to enable EPT with
 ///
-void map_1g(memory_map &mem_map, gpa_t gpa, hpa_t hpa);
+void enable_ept(uint64_t eptp);
+
+/// Disable EPT
+///
+/// @expects
+/// @ensures
+///
+void disable_ept(void);
+
+//--------------------------------------------------------------------------
+// 1GB pages
+//--------------------------------------------------------------------------
 
 /// Map 1GB of memory from the guest physical address to host physical address
 /// with the given memory attributes
@@ -66,22 +70,44 @@ void map_1g(memory_map &mem_map, gpa_t gpa, hpa_t hpa);
 /// @expects
 /// @ensures
 ///
-/// @param mem_map the memory map to calculate EPTP for
+/// @param mem_map the memory map to be modified
 /// @param gpa the guest physical address to map from
 /// @param hpa the host physical address to map to
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
-void map_1g(memory_map &mem_map, gpa_t gpa, hpa_t hpa, memory_attr_t mattr);
+void map_1g(memory_map &mem_map, gpa_t gpa, hpa_t hpa,
+        memory_attr_t mattr = epte::memory_attr::wb_pt);
 
-/// Identity map 1GB of memory from the guest physical address
+/// Map n number of contiguous 1GB page frames from the given guest physical
+/// address to given host physical address with the given memory attributes
 ///
 /// @expects
 /// @ensures
 ///
-/// @param mem_map the memory map to calculate EPTP for
+/// @param mem_map the memory map to be modified
 /// @param gpa the guest physical address to map from
+/// @param hpa the host physical address to map to
+/// @param n the number of contiguous pages to map
+/// @param mattr page table entry memory attributes to be applied to the mapping
 ///
-void identity_map_1g(memory_map &mem_map, gpa_t gpa);
+void map_n_contig_1g(memory_map &mem_map, gpa_t gpa, hpa_t hpa, uint64_t n,
+        memory_attr_t mattr = epte::memory_attr::wb_pt);
+
+/// Map the range of guest physical addresses from gpa_s to gpa_e (inclusive)
+/// to a continuous range of host physical addresses starting at hpa using 1GB
+/// page frames and the given memory attributes
+///
+/// @expects gpa_s < gpa_e
+/// @ensures
+///
+/// @param mem_map the memory map to be modified
+/// @param gpa_s the guest physical address to start mapping from
+/// @param gpa_e the guest physical address to end mapping to
+/// @param hpa the host physical address to map to
+/// @param mattr page table entry memory attributes to be applied to the mapping
+///
+void map_range_1g(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e, hpa_t hpa,
+        memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 /// Identity map 1GB of memory from the guest physical address with the given
 /// memory attributes
@@ -89,26 +115,44 @@ void identity_map_1g(memory_map &mem_map, gpa_t gpa);
 /// @expects
 /// @ensures
 ///
-/// @param mem_map the memory map to calculate EPTP for
+/// @param mem_map the memory map to be modified
 /// @param gpa the guest physical address to map from
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
-void identity_map_1g(memory_map &mem_map, gpa_t gpa, memory_attr_t mattr);
+void identity_map_1g(memory_map &mem_map, gpa_t gpa,
+        memory_attr_t mattr = epte::memory_attr::wb_pt);
 
-//--------------------------------------------------------------------------
-// 2MB pages
-//--------------------------------------------------------------------------
-
-/// Map 2MB of memory from the guest physical address to host physical address
+/// Identity map n number of contiguous 1GB page frames from the given guest
+/// physical address with the given memory attributes
 ///
 /// @expects
 /// @ensures
 ///
-/// @param mem_map the memory map to calculate EPTP for
+/// @param mem_map the memory map to be modified
 /// @param gpa the guest physical address to map from
-/// @param hpa the host physical address to map to
+/// @param n the number of contiguous pages to map
+/// @param mattr page table entry memory attributes to be applied to the mapping
 ///
-void map_2m(memory_map &mem_map, gpa_t gpa, hpa_t hpa);
+void identity_map_n_contig_1g(memory_map &mem_map, gpa_t gpa, uint64_t n,
+        memory_attr_t mattr = epte::memory_attr::wb_pt);
+
+/// Identity map the range of guest physical addresses from gpa_s to gpa_e
+/// (inclusive) using 1GB page frames and the given memory attributes
+///
+/// @expects gpa_s < gpa_e
+/// @ensures
+///
+/// @param mem_map the memory map to be modified
+/// @param gpa_s the guest physical address to start mapping from
+/// @param gpa_e the guest physical address to end mapping to
+/// @param mattr page table entry memory attributes to be applied to the mapping
+///
+void identity_map_range_1g(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e,
+        memory_attr_t mattr = epte::memory_attr::wb_pt);
+
+//--------------------------------------------------------------------------
+// 2MB pages
+//--------------------------------------------------------------------------
 
 /// Map 2MB of memory from the guest physical address to host physical address
 /// with the given memory attributes
@@ -116,22 +160,44 @@ void map_2m(memory_map &mem_map, gpa_t gpa, hpa_t hpa);
 /// @expects
 /// @ensures
 ///
-/// @param mem_map the memory map to calculate EPTP for
+/// @param mem_map the memory map to be modified
 /// @param gpa the guest physical address to map from
 /// @param hpa the host physical address to map to
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
-void map_2m(memory_map &mem_map, gpa_t gpa, hpa_t hpa, memory_attr_t mattr);
+void map_2m(memory_map &mem_map, gpa_t gpa, hpa_t hpa,
+        memory_attr_t mattr = epte::memory_attr::wb_pt);
 
-/// Identity map 2MB of memory from the guest physical address
+/// Map n number of contiguous 2MB page frames from the given guest physical
+/// address to given host physical address with the given memory attributes
 ///
 /// @expects
 /// @ensures
 ///
-/// @param mem_map the memory map to calculate EPTP for
+/// @param mem_map the memory map to be modified
 /// @param gpa the guest physical address to map from
+/// @param hpa the host physical address to map to
+/// @param n the number of contiguous pages to map
+/// @param mattr page table entry memory attributes to be applied to the mapping
 ///
-void identity_map_2m(memory_map &mem_map, gpa_t gpa);
+void map_n_contig_2m(memory_map &mem_map, gpa_t gpa, hpa_t hpa, uint64_t n,
+        memory_attr_t mattr = epte::memory_attr::wb_pt);
+
+/// Map the range of guest physical addresses from gpa_s to gpa_e (inclusive)
+/// to a continuous range of host physical addresses starting at hpa using 2MB
+/// page frames and the given memory attributes
+///
+/// @expects gpa_s < gpa_e
+/// @ensures
+///
+/// @param mem_map the memory map to be modified
+/// @param gpa_s the guest physical address to start mapping from
+/// @param gpa_e the guest physical address to end mapping to
+/// @param hpa the host physical address to map to
+/// @param mattr page table entry memory attributes to be applied to the mapping
+///
+void map_range_2m(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e, hpa_t hpa,
+        memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 /// Identity map 2MB of memory from the guest physical address with the given
 /// memory attributes
@@ -139,26 +205,44 @@ void identity_map_2m(memory_map &mem_map, gpa_t gpa);
 /// @expects
 /// @ensures
 ///
-/// @param mem_map the memory map to calculate EPTP for
+/// @param mem_map the memory map to be modified
 /// @param gpa the guest physical address to map from
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
-void identity_map_2m(memory_map &mem_map, gpa_t gpa, memory_attr_t mattr);
+void identity_map_2m(memory_map &mem_map, gpa_t gpa,
+        memory_attr_t mattr = epte::memory_attr::wb_pt);
 
-//--------------------------------------------------------------------------
-// 4KB pages
-//--------------------------------------------------------------------------
-
-/// Map 4KB of memory from the guest physical address to host physical address
+/// Identity map n number of contiguous 2MB page frames from the given guest
+/// physical address with the given memory attributes
 ///
 /// @expects
 /// @ensures
 ///
-/// @param mem_map the memory map to calculate EPTP for
+/// @param mem_map the memory map to be modified
 /// @param gpa the guest physical address to map from
-/// @param hpa the host physical address to map to
+/// @param n the number of contiguous pages to map
+/// @param mattr page table entry memory attributes to be applied to the mapping
 ///
-void map_4k(memory_map &mem_map, gpa_t gpa, hpa_t hpa);
+void identity_map_n_contig_2m(memory_map &mem_map, gpa_t gpa, uint64_t n,
+        memory_attr_t mattr = epte::memory_attr::wb_pt);
+
+/// Identity map the range of guest physical addresses from gpa_s to gpa_e
+/// (inclusive) using 2MB page frames and the given memory attributes
+///
+/// @expects gpa_s < gpa_e
+/// @ensures
+///
+/// @param mem_map the memory map to be modified
+/// @param gpa_s the guest physical address to start mapping from
+/// @param gpa_e the guest physical address to end mapping to
+/// @param mattr page table entry memory attributes to be applied to the mapping
+///
+void identity_map_range_2m(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e,
+        memory_attr_t mattr = epte::memory_attr::wb_pt);
+
+//--------------------------------------------------------------------------
+// 4KB pages
+//--------------------------------------------------------------------------
 
 /// Map 4KB of memory from the guest physical address to host physical address
 /// with the given memory attributes
@@ -166,22 +250,44 @@ void map_4k(memory_map &mem_map, gpa_t gpa, hpa_t hpa);
 /// @expects
 /// @ensures
 ///
-/// @param mem_map the memory map to calculate EPTP for
+/// @param mem_map the memory map to be modified
 /// @param gpa the guest physical address to map from
 /// @param hpa the host physical address to map to
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
-void map_4k(memory_map &mem_map, gpa_t gpa, hpa_t hpa, memory_attr_t mattr);
+void map_4k(memory_map &mem_map, gpa_t gpa, hpa_t hpa,
+        memory_attr_t mattr = epte::memory_attr::wb_pt);
 
-/// Identity map 4KB of memory from the guest physical address
+/// Map n number of contiguous 4KB page frames from the given guest physical
+/// address to given host physical address with the given memory attributes
 ///
 /// @expects
 /// @ensures
 ///
-/// @param mem_map the memory map to calculate EPTP for
+/// @param mem_map the memory map to be modified
 /// @param gpa the guest physical address to map from
+/// @param hpa the host physical address to map to
+/// @param n the number of contiguous pages to map
+/// @param mattr page table entry memory attributes to be applied to the mapping
 ///
-void identity_map_4k(memory_map &mem_map, gpa_t gpa);
+void map_n_contig_4k(memory_map &mem_map, gpa_t gpa, hpa_t hpa, uint64_t n,
+        memory_attr_t mattr = epte::memory_attr::wb_pt);
+
+/// Map the range of guest physical addresses from gpa_s to gpa_e (inclusive)
+/// to a continuous range of host physical addresses starting at hpa using 4KB
+/// page frames and the given memory attributes
+///
+/// @expects gpa_s < gpa_e
+/// @ensures
+///
+/// @param mem_map the memory map to be modified
+/// @param gpa_s the guest physical address to start mapping from
+/// @param gpa_e the guest physical address to end mapping to
+/// @param hpa the host physical address to map to
+/// @param mattr page table entry memory attributes to be applied to the mapping
+///
+void map_range_4k(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e, hpa_t hpa,
+        memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 /// Identity map 4KB of memory from the guest physical address with the given
 /// memory attributes
@@ -189,18 +295,51 @@ void identity_map_4k(memory_map &mem_map, gpa_t gpa);
 /// @expects
 /// @ensures
 ///
-/// @param mem_map the memory map to calculate EPTP for
+/// @param mem_map the memory map to be modified
 /// @param gpa the guest physical address to map from
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
-void identity_map_4k(memory_map &mem_map, gpa_t gpa, memory_attr_t mattr);
+void identity_map_4k(memory_map &mem_map, gpa_t gpa,
+        memory_attr_t mattr = epte::memory_attr::wb_pt);
+
+/// Identity map n number of contiguous 4KB page frames from the given guest
+/// physical address with the given memory attributes
+///
+/// @expects
+/// @ensures
+///
+/// @param mem_map the memory map to be modified
+/// @param gpa the guest physical address to map from
+/// @param n the number of contiguous pages to map
+/// @param mattr page table entry memory attributes to be applied to the mapping
+///
+void identity_map_n_contig_4k(memory_map &mem_map, gpa_t gpa, uint64_t n,
+        memory_attr_t mattr = epte::memory_attr::wb_pt);
+
+/// Identity map the range of guest physical addresses from gpa_s to gpa_e
+/// (inclusive) using 4KB page frames and the given memory attributes
+///
+/// @expects gpa_s < gpa_e
+/// @ensures
+///
+/// @param mem_map the memory map to be modified
+/// @param gpa_s the guest physical address to start mapping from
+/// @param gpa_e the guest physical address to end mapping to
+/// @param mattr page table entry memory attributes to be applied to the mapping
+///
+void identity_map_range_4k(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e,
+        memory_attr_t mattr = epte::memory_attr::wb_pt);
+
+//--------------------------------------------------------------------------
+// Unmapping
+//--------------------------------------------------------------------------
 
 /// Unmap the given guest physical address
 ///
 /// @expects
 /// @ensures
 ///
-/// @param mem_map the memory map to calculate EPTP for
+/// @param mem_map the memory map to be modified
 /// @param gpa the guest physical address to be unmapped
 ///
 void unmap(memory_map &mem_map, gpa_t gpa);

--- a/bfvmm/src/hve/arch/intel_x64/ept/helpers.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/ept/helpers.cpp
@@ -18,9 +18,11 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <intrinsics.h>
+#include "hve/arch/intel_x64/ept/helpers.h"
 #include "hve/arch/intel_x64/ept/memory_map.h"
 #include "hve/arch/intel_x64/ept/intrinsics.h"
 
+namespace vmcs = intel_x64::vmcs;
 namespace eptp = intel_x64::vmcs::ept_pointer;
 
 namespace eapis
@@ -45,61 +47,167 @@ eptp(memory_map &map)
 }
 
 void
-map_1g(memory_map &mem_map, gpa_t gpa, hpa_t hpa)
-{ mem_map.map(gpa, hpa, pdpte::page_size_bytes); }
+enable_ept(uint64_t eptp)
+{
+    vmcs::ept_pointer::set(eptp);
+    vmcs::secondary_processor_based_vm_execution_controls::enable_vpid::enable();
+    vmcs::secondary_processor_based_vm_execution_controls::enable_ept::enable();
+}
+
+void
+disable_ept(void)
+{ vmcs::secondary_processor_based_vm_execution_controls::enable_ept::disable(); }
+
+//--------------------------------------------------------------------------
+// 1GB pages
+//--------------------------------------------------------------------------
 
 void
 map_1g(memory_map &mem_map, gpa_t gpa, hpa_t hpa, memory_attr_t mattr)
 {
-    auto entry = mem_map.map(gpa, hpa, pdpte::page_size_bytes);
+    auto &entry = mem_map.map(gpa, hpa, pdpte::page_size_bytes);
     epte::memory_attr::set(entry, mattr);
 }
 
 void
-identity_map_1g(memory_map &mem_map, gpa_t gpa)
-{ map_1g(mem_map, gpa, gpa); }
+map_n_contig_1g(memory_map &mem_map, gpa_t gpa, hpa_t hpa, uint64_t n, memory_attr_t mattr)
+{
+    for (auto i = 0ULL; i < n; i++) {
+        map_1g(mem_map, gpa + (i * page_size_1g), hpa + (i * page_size_1g), mattr);
+    }
+}
+
+void
+map_range_1g(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e, hpa_t hpa, memory_attr_t mattr)
+{
+    expects(gpa_s < gpa_e);
+
+    auto n = ((gpa_e - gpa_s) / page_size_1g) + 1ULL;
+    map_n_contig_1g(mem_map, gpa_s, hpa, n, mattr);
+}
 
 void
 identity_map_1g(memory_map &mem_map, gpa_t gpa, memory_attr_t mattr)
 { map_1g(mem_map, gpa, gpa, mattr); }
 
 void
-map_2m(memory_map &mem_map, gpa_t gpa, hpa_t hpa)
-{ mem_map.map(gpa, hpa, pde::page_size_bytes); }
+identity_map_n_contig_1g(memory_map &mem_map, gpa_t gpa, uint64_t n, memory_attr_t mattr)
+{
+    for (auto i = 0ULL; i < n; i++) {
+        identity_map_1g(mem_map, gpa + (i * page_size_1g), mattr);
+    }
+}
+
+void
+identity_map_range_1g(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e, memory_attr_t mattr)
+{
+    expects(gpa_s < gpa_e);
+
+    auto n = ((gpa_e - gpa_s) / page_size_1g) + 1ULL;
+    identity_map_n_contig_1g(mem_map, gpa_s, n, mattr);
+}
+
+//--------------------------------------------------------------------------
+// 2MB pages
+//--------------------------------------------------------------------------
 
 void
 map_2m(memory_map &mem_map, gpa_t gpa, hpa_t hpa, memory_attr_t mattr)
 {
-    auto entry = mem_map.map(gpa, hpa, pde::page_size_bytes);
+    auto &entry = mem_map.map(gpa, hpa, pde::page_size_bytes);
     epte::memory_attr::set(entry, mattr);
 }
 
 void
-identity_map_2m(memory_map &mem_map, gpa_t gpa)
-{ map_2m(mem_map, gpa, gpa); }
+map_n_contig_2m(memory_map &mem_map, gpa_t gpa, hpa_t hpa, uint64_t n, memory_attr_t mattr)
+{
+    for (auto i = 0ULL; i < n; i++) {
+        map_2m(mem_map, gpa + (i * page_size_2m), hpa + (i * page_size_2m), mattr);
+    }
+}
+
+void
+map_range_2m(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e, hpa_t hpa, memory_attr_t mattr)
+{
+    expects(gpa_s < gpa_e);
+
+    auto n = ((gpa_e - gpa_s) / page_size_2m) + 1ULL;
+    map_n_contig_2m(mem_map, gpa_s, hpa, n, mattr);
+}
 
 void
 identity_map_2m(memory_map &mem_map, gpa_t gpa, memory_attr_t mattr)
 { map_2m(mem_map, gpa, gpa, mattr); }
 
 void
-map_4k(memory_map &mem_map, gpa_t gpa, hpa_t hpa)
-{ mem_map.map(gpa, hpa, pte::page_size_bytes); }
+identity_map_n_contig_2m(memory_map &mem_map, gpa_t gpa, uint64_t n, memory_attr_t mattr)
+{
+    for (auto i = 0ULL; i < n; i++) {
+        identity_map_2m(mem_map, gpa + (i * page_size_2m), mattr);
+    }
+}
+
+void
+identity_map_range_2m(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e, memory_attr_t mattr)
+{
+    expects(gpa_s < gpa_e);
+
+    auto n = ((gpa_e - gpa_s) / page_size_2m) + 1ULL;
+    identity_map_n_contig_2m(mem_map, gpa_s, n, mattr);
+}
+
+//--------------------------------------------------------------------------
+// 4KB pages
+//--------------------------------------------------------------------------
 
 void
 map_4k(memory_map &mem_map, gpa_t gpa, hpa_t hpa, memory_attr_t mattr)
 {
-    auto entry = mem_map.map(gpa, hpa, pte::page_size_bytes);
+    auto &entry = mem_map.map(gpa, hpa, pte::page_size_bytes);
     epte::memory_attr::set(entry, mattr);
 }
 
 void
-identity_map_4k(memory_map &mem_map, gpa_t gpa)
-{ map_4k(mem_map, gpa, gpa); }
+map_n_contig_4k(memory_map &mem_map, gpa_t gpa, hpa_t hpa, uint64_t n, memory_attr_t mattr)
+{
+    for (auto i = 0ULL; i < n; i++) {
+        map_4k(mem_map, gpa + (i * page_size_4k), hpa + (i * page_size_4k), mattr);
+    }
+}
+
+void
+map_range_4k(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e, hpa_t hpa, memory_attr_t mattr)
+{
+    expects(gpa_s < gpa_e);
+
+    auto n = ((gpa_e - gpa_s) / page_size_4k) + 1ULL;
+    map_n_contig_4k(mem_map, gpa_s, hpa, n, mattr);
+}
 
 void
 identity_map_4k(memory_map &mem_map, gpa_t gpa, memory_attr_t mattr)
 { map_4k(mem_map, gpa, gpa, mattr); }
+
+void
+identity_map_n_contig_4k(memory_map &mem_map, gpa_t gpa, uint64_t n, memory_attr_t mattr)
+{
+    for (auto i = 0ULL; i < n; i++) {
+        identity_map_4k(mem_map, gpa + (i * page_size_4k), mattr);
+    }
+}
+
+void
+identity_map_range_4k(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e, memory_attr_t mattr)
+{
+    expects(gpa_s < gpa_e);
+
+    auto n = ((gpa_e - gpa_s) / page_size_4k) + 1ULL;
+    identity_map_n_contig_4k(mem_map, gpa_s, n, mattr);
+}
+
+//--------------------------------------------------------------------------
+// Unmapping
+//--------------------------------------------------------------------------
 
 void
 unmap(memory_map &mem_map, gpa_t gpa)

--- a/bfvmm/tests/hve/arch/intel_x64/ept/test_helpers.cpp
+++ b/bfvmm/tests/hve/arch/intel_x64/ept/test_helpers.cpp
@@ -18,6 +18,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <intrinsics.h>
+#include <support/arch/intel_x64/test_support.h>
 #include "ept_test_support.h"
 
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
@@ -26,10 +27,6 @@ namespace eptp = intel_x64::vmcs::ept_pointer;
 
 namespace test_ept
 {
-
-extern "C" uint64_t unsafe_write_cstr(const char *cstr, size_t len)
-{ bfignored(cstr); bfignored(len); return 0; }
-
 
 TEST_CASE("ept::eptp")
 {
@@ -45,6 +42,10 @@ TEST_CASE("ept::eptp")
     uint64_t eptp_val = ept::eptp(*mem_map);
     CHECK(eptp_val == expected);
 }
+
+//--------------------------------------------------------------------------
+// 1GB pages
+//--------------------------------------------------------------------------
 
 TEST_CASE("ept::map_1g")
 {
@@ -68,13 +69,131 @@ TEST_CASE("ept::map_1g with attributes")
     auto mem_map = std::make_unique<ept::memory_map>();
     uintptr_t gpa = test_ept::g_unmapped_gpa;
     uintptr_t hpa = test_ept::mock_1g_hpa;
-    ept::memory_attr_t mtype = ept::epte::memory_attr::wb_rw;
+    ept::memory_attr_t mtype = ept::epte::memory_attr::uc_eo;
     ept::epte_t result_entry{0ULL};
 
     ept::map_1g(*mem_map, gpa, hpa, mtype);
     CHECK_THROWS(ept::map_1g(*mem_map, gpa, hpa, mtype));
     result_entry = mem_map->gpa_to_epte(gpa);
     CHECK(ept::epte::hpa(result_entry) == hpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+}
+
+TEST_CASE("ept::map_n_contig_1g")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t hpa = gpa + ept::page_size_1g;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_1g);
+    uintptr_t end_hpa = hpa + ((page_count - 1) * ept::page_size_1g);
+    ept::epte_t result_entry{0ULL};
+
+    ept::map_n_contig_1g(*mem_map, gpa, hpa, page_count);
+    CHECK_THROWS(ept::map_1g(*mem_map, gpa, hpa));
+    CHECK_THROWS(ept::map_1g(*mem_map, end_gpa, end_hpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_1g));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == hpa);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_hpa);
+}
+
+TEST_CASE("ept::map_n_contig_1g with attributes")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t hpa = gpa + ept::page_size_1g;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_1g);
+    uintptr_t end_hpa = hpa + ((page_count - 1) * ept::page_size_1g);
+    auto mattr = ept::epte::memory_attr::uc_eo;
+    ept::epte_t result_entry{0ULL};
+
+    ept::map_n_contig_1g(*mem_map, gpa, hpa, page_count, mattr);
+    CHECK_THROWS(ept::map_1g(*mem_map, gpa, hpa));
+    CHECK_THROWS(ept::map_1g(*mem_map, end_gpa, end_hpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_1g));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == hpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_hpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+}
+
+TEST_CASE("ept::map_range_1g")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t hpa = gpa + ept::page_size_1g;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_1g);
+    uintptr_t end_hpa = hpa + ((page_count - 1) * ept::page_size_1g);
+    ept::epte_t result_entry{0ULL};
+
+    ept::map_range_1g(*mem_map, gpa, end_gpa, hpa);
+    CHECK_THROWS(ept::map_1g(*mem_map, gpa, hpa));
+    CHECK_THROWS(ept::map_1g(*mem_map, end_gpa, end_hpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_1g));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == hpa);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_hpa);
+}
+
+TEST_CASE("ept::map_range_1g with attributes")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t hpa = gpa + ept::page_size_1g;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_1g);
+    uintptr_t end_hpa = hpa + ((page_count - 1) * ept::page_size_1g);
+    auto mattr = ept::epte::memory_attr::uc_eo;
+    ept::epte_t result_entry{0ULL};
+
+    ept::map_range_1g(*mem_map, gpa, end_gpa, hpa, mattr);
+    CHECK_THROWS(ept::map_1g(*mem_map, gpa, hpa));
+    CHECK_THROWS(ept::map_1g(*mem_map, end_gpa, end_hpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_1g));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == hpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_hpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
 }
 
 TEST_CASE("ept::identity_map_1g")
@@ -98,14 +217,128 @@ TEST_CASE("ept::identity_map_1g with attributes")
     auto mock_ept = std::make_unique<ept_test_support>(mocks);
     auto mem_map = std::make_unique<ept::memory_map>();
     uintptr_t gpa = test_ept::g_unmapped_gpa;
-    ept::memory_attr_t mtype = ept::epte::memory_attr::wb_rw;
+    ept::memory_attr_t mtype = ept::epte::memory_attr::uc_eo;
     ept::epte_t result_entry{0ULL};
 
     ept::identity_map_1g(*mem_map, gpa, mtype);
     CHECK_THROWS(ept::identity_map_1g(*mem_map, gpa));
     result_entry = mem_map->gpa_to_epte(gpa);
     CHECK(ept::epte::hpa(result_entry) == gpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
 }
+
+TEST_CASE("ept::identity_map_n_contig_1g")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_1g);
+    ept::epte_t result_entry{0ULL};
+
+    ept::identity_map_n_contig_1g(*mem_map, gpa, page_count);
+    CHECK_THROWS(ept::map_1g(*mem_map, gpa, gpa));
+    CHECK_THROWS(ept::map_1g(*mem_map, end_gpa, end_gpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_1g));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == gpa);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_gpa);
+}
+
+TEST_CASE("ept::identity_map_n_contig_1g with attributes")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_1g);
+    auto mattr = ept::epte::memory_attr::uc_eo;
+    ept::epte_t result_entry{0ULL};
+
+    ept::identity_map_n_contig_1g(*mem_map, gpa, page_count, mattr);
+    CHECK_THROWS(ept::map_1g(*mem_map, gpa, gpa));
+    CHECK_THROWS(ept::map_1g(*mem_map, end_gpa, end_gpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_1g));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == gpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_gpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+}
+
+TEST_CASE("ept::identity_map_range_1g")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_1g);
+    ept::epte_t result_entry{0ULL};
+
+    ept::identity_map_range_1g(*mem_map, gpa, end_gpa);
+    CHECK_THROWS(ept::map_1g(*mem_map, gpa, gpa));
+    CHECK_THROWS(ept::map_1g(*mem_map, end_gpa, end_gpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_1g));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == gpa);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_gpa);
+}
+
+TEST_CASE("ept::identity_map_range_1g with attributes")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_1g);
+    auto mattr = ept::epte::memory_attr::uc_eo;
+    ept::epte_t result_entry{0ULL};
+
+    ept::identity_map_range_1g(*mem_map, gpa, end_gpa, mattr);
+    CHECK_THROWS(ept::map_1g(*mem_map, gpa, gpa));
+    CHECK_THROWS(ept::map_1g(*mem_map, end_gpa, end_gpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_1g));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == gpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_gpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+}
+
+//--------------------------------------------------------------------------
+// 2MB pages
+//--------------------------------------------------------------------------
 
 TEST_CASE("ept::map_2m")
 {
@@ -129,13 +362,131 @@ TEST_CASE("ept::map_2m with attributes")
     auto mem_map = std::make_unique<ept::memory_map>();
     uintptr_t gpa = test_ept::g_unmapped_gpa;
     uintptr_t hpa = test_ept::mock_2m_hpa;
-    ept::memory_attr_t mtype = ept::epte::memory_attr::wb_rw;
+    ept::memory_attr_t mtype = ept::epte::memory_attr::uc_eo;
     ept::epte_t result_entry{0ULL};
 
     ept::map_2m(*mem_map, gpa, hpa, mtype);
     CHECK_THROWS(ept::map_2m(*mem_map, gpa, hpa, mtype));
     result_entry = mem_map->gpa_to_epte(gpa);
     CHECK(ept::epte::hpa(result_entry) == hpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+}
+
+TEST_CASE("ept::map_n_contig_2m")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t hpa = gpa + ept::page_size_2m;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_2m);
+    uintptr_t end_hpa = hpa + ((page_count - 1) * ept::page_size_2m);
+    ept::epte_t result_entry{0ULL};
+
+    ept::map_n_contig_2m(*mem_map, gpa, hpa, page_count);
+    CHECK_THROWS(ept::map_2m(*mem_map, gpa, hpa));
+    CHECK_THROWS(ept::map_2m(*mem_map, end_gpa, end_hpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_2m));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == hpa);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_hpa);
+}
+
+TEST_CASE("ept::map_n_contig_2m with attributes")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t hpa = gpa + ept::page_size_2m;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_2m);
+    uintptr_t end_hpa = hpa + ((page_count - 1) * ept::page_size_2m);
+    auto mattr = ept::epte::memory_attr::uc_eo;
+    ept::epte_t result_entry{0ULL};
+
+    ept::map_n_contig_2m(*mem_map, gpa, hpa, page_count, mattr);
+    CHECK_THROWS(ept::map_2m(*mem_map, gpa, hpa));
+    CHECK_THROWS(ept::map_2m(*mem_map, end_gpa, end_hpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_2m));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == hpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_hpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+}
+
+TEST_CASE("ept::map_range_2m")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t hpa = gpa + ept::page_size_2m;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_2m);
+    uintptr_t end_hpa = hpa + ((page_count - 1) * ept::page_size_2m);
+    ept::epte_t result_entry{0ULL};
+
+    ept::map_range_2m(*mem_map, gpa, end_gpa, hpa);
+    CHECK_THROWS(ept::map_2m(*mem_map, gpa, hpa));
+    CHECK_THROWS(ept::map_2m(*mem_map, end_gpa, end_hpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_2m));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == hpa);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_hpa);
+}
+
+TEST_CASE("ept::map_range_2m with attributes")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t hpa = gpa + ept::page_size_2m;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_2m);
+    uintptr_t end_hpa = hpa + ((page_count - 1) * ept::page_size_2m);
+    auto mattr = ept::epte::memory_attr::uc_eo;
+    ept::epte_t result_entry{0ULL};
+
+    ept::map_range_2m(*mem_map, gpa, end_gpa, hpa, mattr);
+    CHECK_THROWS(ept::map_2m(*mem_map, gpa, hpa));
+    CHECK_THROWS(ept::map_2m(*mem_map, end_gpa, end_hpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_2m));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == hpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_hpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
 }
 
 TEST_CASE("ept::identity_map_2m")
@@ -159,14 +510,128 @@ TEST_CASE("ept::identity_map_2m with attributes")
     auto mock_ept = std::make_unique<ept_test_support>(mocks);
     auto mem_map = std::make_unique<ept::memory_map>();
     uintptr_t gpa = test_ept::g_unmapped_gpa;
-    ept::memory_attr_t mtype = ept::epte::memory_attr::wb_rw;
+    ept::memory_attr_t mtype = ept::epte::memory_attr::uc_eo;
     ept::epte_t result_entry{0ULL};
 
     ept::identity_map_2m(*mem_map, gpa, mtype);
     CHECK_THROWS(ept::identity_map_2m(*mem_map, gpa));
     result_entry = mem_map->gpa_to_epte(gpa);
     CHECK(ept::epte::hpa(result_entry) == gpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
 }
+
+TEST_CASE("ept::identity_map_n_contig_2m")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_2m);
+    ept::epte_t result_entry{0ULL};
+
+    ept::identity_map_n_contig_2m(*mem_map, gpa, page_count);
+    CHECK_THROWS(ept::map_2m(*mem_map, gpa, gpa));
+    CHECK_THROWS(ept::map_2m(*mem_map, end_gpa, end_gpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_2m));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == gpa);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_gpa);
+}
+
+TEST_CASE("ept::identity_map_n_contig_2m with attributes")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_2m);
+    auto mattr = ept::epte::memory_attr::uc_eo;
+    ept::epte_t result_entry{0ULL};
+
+    ept::identity_map_n_contig_2m(*mem_map, gpa, page_count, mattr);
+    CHECK_THROWS(ept::map_2m(*mem_map, gpa, gpa));
+    CHECK_THROWS(ept::map_2m(*mem_map, end_gpa, end_gpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_2m));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == gpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_gpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+}
+
+TEST_CASE("ept::identity_map_range_2m")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_2m);
+    ept::epte_t result_entry{0ULL};
+
+    ept::identity_map_range_2m(*mem_map, gpa, end_gpa);
+    CHECK_THROWS(ept::map_2m(*mem_map, gpa, gpa));
+    CHECK_THROWS(ept::map_2m(*mem_map, end_gpa, end_gpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_2m));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == gpa);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_gpa);
+}
+
+TEST_CASE("ept::identity_map_range_2m with attributes")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_2m);
+    auto mattr = ept::epte::memory_attr::uc_eo;
+    ept::epte_t result_entry{0ULL};
+
+    ept::identity_map_range_2m(*mem_map, gpa, end_gpa, mattr);
+    CHECK_THROWS(ept::map_2m(*mem_map, gpa, gpa));
+    CHECK_THROWS(ept::map_2m(*mem_map, end_gpa, end_gpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_2m));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == gpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_gpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+}
+
+//--------------------------------------------------------------------------
+// 4KB pages
+//--------------------------------------------------------------------------
 
 TEST_CASE("ept::map_4k")
 {
@@ -190,13 +655,131 @@ TEST_CASE("ept::map_4k with attributes")
     auto mem_map = std::make_unique<ept::memory_map>();
     uintptr_t gpa = test_ept::g_unmapped_gpa;
     uintptr_t hpa = test_ept::mock_4k_hpa;
-    ept::memory_attr_t mtype = ept::epte::memory_attr::wb_rw;
+    ept::memory_attr_t mtype = ept::epte::memory_attr::uc_eo;
     ept::epte_t result_entry{0ULL};
 
     ept::map_4k(*mem_map, gpa, hpa, mtype);
     CHECK_THROWS(ept::map_4k(*mem_map, gpa, hpa, mtype));
     result_entry = mem_map->gpa_to_epte(gpa);
     CHECK(ept::epte::hpa(result_entry) == hpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+}
+
+TEST_CASE("ept::map_n_contig_4k")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t hpa = gpa + ept::page_size_4k;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_4k);
+    uintptr_t end_hpa = hpa + ((page_count - 1) * ept::page_size_4k);
+    ept::epte_t result_entry{0ULL};
+
+    ept::map_n_contig_4k(*mem_map, gpa, hpa, page_count);
+    CHECK_THROWS(ept::map_4k(*mem_map, gpa, hpa));
+    CHECK_THROWS(ept::map_4k(*mem_map, end_gpa, end_hpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_4k));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == hpa);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_hpa);
+}
+
+TEST_CASE("ept::map_n_contig_4k with attributes")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t hpa = gpa + ept::page_size_4k;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_4k);
+    uintptr_t end_hpa = hpa + ((page_count - 1) * ept::page_size_4k);
+    auto mattr = ept::epte::memory_attr::uc_eo;
+    ept::epte_t result_entry{0ULL};
+
+    ept::map_n_contig_4k(*mem_map, gpa, hpa, page_count, mattr);
+    CHECK_THROWS(ept::map_4k(*mem_map, gpa, hpa));
+    CHECK_THROWS(ept::map_4k(*mem_map, end_gpa, end_hpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_4k));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == hpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_hpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+}
+
+TEST_CASE("ept::map_range_4k")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t hpa = gpa + ept::page_size_4k;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_4k);
+    uintptr_t end_hpa = hpa + ((page_count - 1) * ept::page_size_4k);
+    ept::epte_t result_entry{0ULL};
+
+    ept::map_range_4k(*mem_map, gpa, end_gpa, hpa);
+    CHECK_THROWS(ept::map_4k(*mem_map, gpa, hpa));
+    CHECK_THROWS(ept::map_4k(*mem_map, end_gpa, end_hpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_4k));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == hpa);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_hpa);
+}
+
+TEST_CASE("ept::map_range_4k with attributes")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t hpa = gpa + ept::page_size_4k;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_4k);
+    uintptr_t end_hpa = hpa + ((page_count - 1) * ept::page_size_4k);
+    auto mattr = ept::epte::memory_attr::uc_eo;
+    ept::epte_t result_entry{0ULL};
+
+    ept::map_range_4k(*mem_map, gpa, end_gpa, hpa, mattr);
+    CHECK_THROWS(ept::map_4k(*mem_map, gpa, hpa));
+    CHECK_THROWS(ept::map_4k(*mem_map, end_gpa, end_hpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_4k));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == hpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_hpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
 }
 
 TEST_CASE("ept::identity_map_4k")
@@ -220,13 +803,123 @@ TEST_CASE("ept::identity_map_4k with attributes")
     auto mock_ept = std::make_unique<ept_test_support>(mocks);
     auto mem_map = std::make_unique<ept::memory_map>();
     uintptr_t gpa = test_ept::g_unmapped_gpa;
-    ept::memory_attr_t mtype = ept::epte::memory_attr::wb_rw;
+    ept::memory_attr_t mtype = ept::epte::memory_attr::uc_eo;
     ept::epte_t result_entry{0ULL};
 
     ept::identity_map_4k(*mem_map, gpa, mtype);
     CHECK_THROWS(ept::identity_map_4k(*mem_map, gpa));
     result_entry = mem_map->gpa_to_epte(gpa);
     CHECK(ept::epte::hpa(result_entry) == gpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+}
+
+TEST_CASE("ept::identity_map_n_contig_4k")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_4k);
+    ept::epte_t result_entry{0ULL};
+
+    ept::identity_map_n_contig_4k(*mem_map, gpa, page_count);
+    CHECK_THROWS(ept::map_4k(*mem_map, gpa, gpa));
+    CHECK_THROWS(ept::map_4k(*mem_map, end_gpa, end_gpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_4k));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == gpa);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_gpa);
+}
+
+TEST_CASE("ept::identity_map_n_contig_4k with attributes")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_4k);
+    auto mattr = ept::epte::memory_attr::uc_eo;
+    ept::epte_t result_entry{0ULL};
+
+    ept::identity_map_n_contig_4k(*mem_map, gpa, page_count, mattr);
+    CHECK_THROWS(ept::map_4k(*mem_map, gpa, gpa));
+    CHECK_THROWS(ept::map_4k(*mem_map, end_gpa, end_gpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_4k));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == gpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_gpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+}
+
+TEST_CASE("ept::identity_map_range_4k")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_4k);
+    ept::epte_t result_entry{0ULL};
+
+    ept::identity_map_range_4k(*mem_map, gpa, end_gpa);
+    CHECK_THROWS(ept::map_4k(*mem_map, gpa, gpa));
+    CHECK_THROWS(ept::map_4k(*mem_map, end_gpa, end_gpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_4k));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == gpa);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_gpa);
+}
+
+TEST_CASE("ept::identity_map_range_4k with attributes")
+{
+    MockRepository mocks;
+    auto mock_ept = std::make_unique<ept_test_support>(mocks);
+    auto mem_map = std::make_unique<ept::memory_map>();
+    auto page_count = 10ULL;
+    uintptr_t gpa = test_ept::g_unmapped_gpa;
+    uintptr_t end_gpa = gpa + ((page_count - 1) * ept::page_size_4k);
+    auto mattr = ept::epte::memory_attr::uc_eo;
+    ept::epte_t result_entry{0ULL};
+
+    ept::identity_map_range_4k(*mem_map, gpa, end_gpa, mattr);
+    CHECK_THROWS(ept::map_4k(*mem_map, gpa, gpa));
+    CHECK_THROWS(ept::map_4k(*mem_map, end_gpa, end_gpa));
+    CHECK_THROWS(mem_map->gpa_to_epte(end_gpa + ept::page_size_4k));
+
+    result_entry = mem_map->gpa_to_epte(gpa);
+    CHECK(ept::epte::hpa(result_entry) == gpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
+
+    result_entry = mem_map->gpa_to_epte(end_gpa);
+    CHECK(ept::epte::hpa(result_entry) == end_gpa);
+    CHECK(ept::epte::read_access::is_disabled(result_entry));
+    CHECK(ept::epte::write_access::is_disabled(result_entry));
+    CHECK(ept::epte::execute_access::is_enabled(result_entry));
+    CHECK(ept::epte::memory_type::get(result_entry) == ept::epte::memory_type::uc);
 }
 
 }

--- a/bfvmm/tests/hve/arch/intel_x64/ept/test_intrinsics.cpp
+++ b/bfvmm/tests/hve/arch/intel_x64/ept/test_intrinsics.cpp
@@ -20,7 +20,6 @@
 #include <catch/catch.hpp>
 #include <hve/arch/intel_x64/ept/intrinsics.h>
 
-// using namespace eapis::intel_x64::ept::epte;
 namespace eapis
 {
 namespace intel_x64

--- a/bfvmm/tests/hve/arch/intel_x64/ept/test_memory_map.cpp
+++ b/bfvmm/tests/hve/arch/intel_x64/ept/test_memory_map.cpp
@@ -17,15 +17,13 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#include <support/arch/intel_x64/test_support.h>
 #include "ept_test_support.h"
 
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
 namespace test_ept
 {
-
-extern "C" uint64_t unsafe_write_cstr(const char *cstr, size_t len)
-{ bfignored(cstr); bfignored(len); return 0; }
 
 namespace ept = eapis::intel_x64::ept;
 


### PR DESCRIPTION
1) Added EPT helper functions to map by address ranges at each
granularity

2) Added EPT helper functions to map by count of pages at each
granularity

3) Fixed a bug with the existing helpers for mapping with memory
attributes

4) Unit tests for all of the above

Signed-off-by: JaredWright <jared.wright12@gmail.com>