### PR TITLE
Add pci_device_allocator

### DIFF
--- a/bfvmm/include/hve/pci_device_allocator.h
+++ b/bfvmm/include/hve/pci_device_allocator.h
@@ -1,0 +1,180 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef PCI_DEVICE_ALLOCATOR_H
+#define PCI_DEVICE_ALLOCATOR_H
+
+#include "pci_register.h"
+
+namespace eapis
+{
+
+namespace pci
+{
+
+/// Allocator for unique PCI device IDs, both physical and virtual
+class device_allocator
+{
+public:
+
+    /// Status of the allocator after an allocation attempt
+    enum class alloc_status {
+        /// Device was allocated successfully.
+        success,
+
+        /// A specific device ID was requested, but that ID already exists.
+        collision,
+
+        /// A non-bridge device was requested but there is only one remaining
+        /// available device ID on the bus. The last ID is left open to create a
+        /// new bridge. If a specific bus is not required, the remedy for this
+        /// is to allocate a new bridge and try again.
+        bus_almost_full,
+
+        /// There are no remaining devices on the bus. If a bus was specified,
+        /// it is full; if no bus was specified, there are no available device
+        /// IDs on any existing bus. The remedy for this is to deallocate a
+        /// device first, then try again.
+        bus_full,
+
+        /// There are no remaining devices on any bus and there are no remaining
+        /// buses on the system.
+        full,
+    };
+
+
+    /// Create a new, empty allocator.
+    device_allocator();
+
+    /// @cond
+
+    device_allocator(device_allocator &&) noexcept = default;
+    device_allocator &operator=(device_allocator &&) noexcept = default;
+
+    device_allocator(const device_allocator &) = delete;
+    device_allocator &operator=(const device_allocator &) = delete;
+
+    /// @endcond
+
+    /// Populate this allocator from the local system's devices
+    /// @return `success` or `collision`. On collision, the allocator
+    /// has not been modified.
+    alloc_status populate_physical();
+
+    /// Populate this allocator from another allocator
+    /// @param other another allocator from which devices will be copied
+    /// @return `success` or `collision`. On collision, the allocator
+    /// has not been modified.
+    alloc_status populate_from(device_allocator const &other);
+
+    /// Add a specific device to this allocator
+    /// @param device specific device to add
+    /// @return `success` or `collision`. On collision, the allocator
+    /// has not been modified.
+    alloc_status add(device_id device);
+
+    /// Get a new device on the next available bus.
+    /// @param device will be populated with the allocated device, or unmodified on error
+    /// @return `success` or an error code.
+    alloc_status allocate(device_id &device);
+
+    /// Get a new device on the specified bus.
+    /// @param bus bus on which device will be allocated. The bus must exist in the allocator.
+    /// @param device will be populated with the allocated device, or unmodified on error
+    /// @return `success` or an error code.
+    alloc_status allocate(bus_type bus, device_id &device);
+
+    /// Create a new bus, allocating a bus-bus bridge.
+    /// @param device will be populated with the allocated device, or unmodified on error
+    /// @return `success` or an error code.
+    alloc_status allocate_bridge(device_id &device);
+
+    /// Create a new bus, allocating a bus-bus bridge on the specified existing bus.
+    /// @param bus bus on which device will be allocated. The bus must exist in the allocator.
+    /// @param device will be populated with the allocated device, or unmodified on error
+    /// @return `success` or an error code.
+    alloc_status allocate_bridge(bus_type bus, device_id &device);
+
+    /// Return whether this allocator contains a given device
+    /// @param device PCI device ID to test for
+    /// @return true iff the device has been allocated
+    bool contains(device_id device) const;
+
+    /// Deallocate a device. If device is a bus-bus bridge, all devices on the
+    /// secondary bus will also be deallocated.
+    /// @param device PCI device ID to deallocate
+    void deallocate(device_id device);
+
+    /// Clear all allocated and populated devices
+    void clear();
+
+    /// Fill a vector with all devices this allocator contains
+    /// @param devices vector to which all allocated devices will be added
+    void enumerate(std::vector<device_id> &devices) const;
+
+private:
+    /// Bitmaps, one bit per device, for each bus
+    std::vector<uint32_t> m_buses;
+
+    /// Secondary bus number for each bridge, stored at index (device << 8) | bus
+    std::vector<bus_type> m_bridges_allocated;
+
+    /// Access the element in m_bridges_allocated for a given device
+    /// @param device device number (must be <= 31)
+    /// @param bus bus number
+    /// @throws std::logic_error if device > 31
+    bus_type &secondary_bus_element(bus_type bus, device_type device);
+
+    /// Access the element in m_bridges_allocated for a given device
+    /// @param device device number (must be <= 31)
+    /// @param bus bus number
+    /// @throws std::logic_error if device > 31
+    bus_type secondary_bus_element(bus_type bus, device_type device) const;
+
+    /// Find the next available secondary bus number
+    /// @return next available secondary bus, or 0 if none
+    bus_type next_secondary() const;
+
+    /// Validate a device number and throw an exception if invalid.
+    /// @param device device number (should be <= 31)
+    /// @throws std::logic_error if device > 31
+    void check_device(device_type device) const;
+
+    /// Allocate a device, recursing on bridges.
+    /// @param bus starting bus
+    /// @param device will be populated with the allocated device, or unmodified on error
+    /// @param top maximum device ID to allocate
+    /// @return `success` or an error code
+    alloc_status allocate_recursive(bus_type bus, device_id &device, device_type top);
+
+    /// Allocate a device on one bus
+    /// @param bus bus
+    /// @param device will be populated with the allocated device, or unmodified on error
+    /// @param top maximum device ID to allocate
+    /// @return `success` or an error code
+    alloc_status allocate_nonrecursive(bus_type bus, device_id &device, device_type top);
+
+    /// Check whether a specific device can be added to this allocator. Never modifies.
+    /// @return `success` or `collision`.
+    alloc_status check_add(device_id device) const;
+};
+
+}
+}
+
+#endif

--- a/bfvmm/include/hve/pci_register.h
+++ b/bfvmm/include/hve/pci_register.h
@@ -38,6 +38,22 @@ using func_type = uint8_t;
 /// Type of register index. Should be <= 0x3F
 using register_type = uint8_t;
 
+/// Full geographical address of a device
+struct device_id
+{
+    /// Bus number
+    bus_type bus;
+
+    /// Device number
+    device_type device;
+
+    /// Function number
+    func_type func;
+
+    /// Secondary bus if this is a bridge, else 0
+    bus_type secondary_bus;
+};
+
 ///
 /// @brief Read 8 bits from a geographically addressed register.
 ///

--- a/bfvmm/include/hve/phys_pci.h
+++ b/bfvmm/include/hve/phys_pci.h
@@ -205,6 +205,18 @@ public:
         }
     }
 
+    /// @brief Return the secondary bus if this is a bridge, or 0 otherwise.
+    /// @return secondary bus or 0
+    inline uint8_t secondary_bus() const
+    {
+        if ((header_type() & 0x7F) == 1) {
+            return read_register_u8(0x19);
+        }
+        else {
+            return 0;
+        }
+    }
+
     /// Write a command to the device's command register
     /// @param command command register contents
     inline void send_command(uint16_t command) { rmw_register_u16(0x04, command); }

--- a/bfvmm/src/hve/CMakeLists.txt
+++ b/bfvmm/src/hve/CMakeLists.txt
@@ -56,6 +56,7 @@ endif()
 
 list(APPEND SOURCES
     phys_pci.cpp
+    pci_device_allocator.cpp
 )
 
 add_shared_library(

--- a/bfvmm/src/hve/pci_device_allocator.cpp
+++ b/bfvmm/src/hve/pci_device_allocator.cpp
@@ -1,0 +1,348 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <bfgsl.h>
+#include <bfdebug.h>
+#include <bfconstants.h>
+
+#include <hve/pci_device_allocator.h>
+#include <hve/phys_pci.h>
+
+using bus_type = eapis::pci::bus_type;
+using device_type = eapis::pci::device_type;
+using func_type = eapis::pci::func_type;
+using register_type = eapis::pci::register_type;
+
+using eapis::pci::device_allocator;
+using eapis::pci::device_id;
+
+device_allocator::device_allocator()
+    : m_buses(256, 0),
+      m_bridges_allocated(8192, 0)
+{ }
+
+device_allocator::alloc_status
+device_allocator::populate_physical()
+{
+    std::vector<phys_pci> phys_devices;
+    phys_pci::enumerate(phys_devices);
+
+    for (auto const &phys_device : phys_devices) {
+        device_id device = {
+            phys_device.bus(),
+            phys_device.device(),
+            phys_device.func(),
+            phys_device.secondary_bus()
+        };
+
+        auto status = check_add(device);
+
+        if (status != alloc_status::success) {
+            return status;
+        }
+    }
+
+    for (auto const &phys_device : phys_devices) {
+        device_id device = {
+            phys_device.bus(),
+            phys_device.device(),
+            phys_device.func(),
+            phys_device.secondary_bus()
+        };
+
+        auto status = add(device);
+
+        if (status != alloc_status::success) {
+            throw std::logic_error("device_allocator::check_add() succeeded but add() failed");
+        }
+    }
+
+    return alloc_status::success;
+}
+
+device_allocator::alloc_status
+device_allocator::populate_from(device_allocator const &other)
+{
+    for (size_t bus = 0; bus < m_buses.size(); ++bus) {
+        if ((m_buses[bus] & other.m_buses[bus]) != 0) {
+            return alloc_status::collision;
+        }
+    }
+
+    for (size_t bridge_idx = 0; bridge_idx < m_bridges_allocated.size(); ++bridge_idx) {
+        if (m_bridges_allocated[bridge_idx] != 0 && other.m_bridges_allocated[bridge_idx] != 0) {
+            return alloc_status::collision;
+        }
+    }
+
+    for (size_t bus = 0; bus < m_buses.size(); ++bus) {
+        m_buses[bus] |= other.m_buses[bus];
+    }
+
+    for (size_t bridge_idx = 0; bridge_idx < m_bridges_allocated.size(); ++bridge_idx) {
+        if (other.m_bridges_allocated[bridge_idx] != 0) {
+            m_bridges_allocated[bridge_idx] = other.m_bridges_allocated[bridge_idx];
+        }
+    }
+
+    return alloc_status::success;
+}
+
+device_allocator::alloc_status
+device_allocator::add(device_id device)
+{
+    auto status = check_add(device);
+
+    if (status != alloc_status::success) {
+        return status;
+    }
+
+    m_buses[device.bus] |= (1u << device.device);
+
+    if (device.secondary_bus != 0) {
+        secondary_bus_element(device.bus, device.device) = device.secondary_bus;
+    }
+
+    return alloc_status::success;
+}
+
+device_allocator::alloc_status
+device_allocator::allocate_nonrecursive(bus_type bus, device_id &device, device_type top)
+{
+    for (device_type dev = 0; dev <= top; ++dev) {
+        if ((m_buses[bus] & (1u << dev)) == 0) {
+            m_buses[bus] |= (1u << dev);
+            device.bus = bus;
+            device.device = dev;
+            device.func = 0;
+            device.secondary_bus = 0;
+            return alloc_status::success;
+        }
+    }
+
+    if (top == 31 || (((1u << (top + 1)) - 1u) | m_buses[bus]) == 0xFFFFFFFFu) {
+        return alloc_status::bus_full;
+    }
+    else {
+        return alloc_status::bus_almost_full;
+    }
+}
+
+device_allocator::alloc_status
+device_allocator::allocate_recursive(bus_type bus, device_id &device, device_type top)
+{
+    if (allocate_nonrecursive(bus, device, top) == alloc_status::success) {
+        return alloc_status::success;
+    }
+
+    for (device_type dev = 0; dev <= 31; ++dev) {
+        bus_type secbus = secondary_bus_element(bus, dev);
+
+        if (secbus != 0) {
+            device_allocator::alloc_status status = allocate_recursive(secbus, device, top);
+
+            if (status == alloc_status::success) {
+                return alloc_status::success;
+            }
+        }
+    }
+
+    if (top == 31 || (((1u << (top + 1)) - 1u) | m_buses[bus]) == 0xFFFFFFFFu) {
+        return alloc_status::bus_full;
+    }
+    else {
+        return alloc_status::bus_almost_full;
+    }
+}
+
+device_allocator::alloc_status
+device_allocator::allocate(device_id &device)
+{
+    return allocate_recursive(0, device, 30);
+}
+
+device_allocator::alloc_status
+device_allocator::allocate(bus_type bus, device_id &device)
+{
+    return allocate_nonrecursive(bus, device, 30);
+}
+
+device_allocator::alloc_status
+device_allocator::allocate_bridge(device_id &device)
+{
+    bus_type next_bus = next_secondary();
+
+    if (next_bus == 0) {
+        return alloc_status::full;
+    }
+
+    auto status = allocate_recursive(0, device, 31);
+
+    if (status == alloc_status::success) {
+        device.secondary_bus = next_bus;
+        secondary_bus_element(device.bus, device.device) = device.secondary_bus;
+    }
+
+    return status;
+}
+
+device_allocator::alloc_status
+device_allocator::allocate_bridge(bus_type bus, device_id &device)
+{
+    bus_type next_bus = next_secondary();
+
+    if (next_bus == 0) {
+        return alloc_status::full;
+    }
+
+    auto status = allocate_nonrecursive(bus, device, 31);
+
+    if (status == alloc_status::success) {
+        device.secondary_bus = gsl::narrow_cast<bus_type>(next_bus);
+        secondary_bus_element(device.bus, device.device) = device.secondary_bus;
+    }
+
+    return status;
+}
+
+bool
+device_allocator::contains(device_id device) const
+{
+    check_device(device.device);
+
+    return (m_buses[device.bus] & (1u << device.device)) != 0;
+}
+
+void
+device_allocator::deallocate(device_id device)
+{
+    check_device(device.device);
+
+    bus_type &secbus = secondary_bus_element(device.bus, device.device);
+
+    if (secbus != 0) {
+        m_buses[secbus] = 0;
+        secbus = 0;
+    }
+
+    m_buses[device.bus] &= ~(1u << device.device);
+}
+
+void
+device_allocator::clear()
+{
+    for (auto &i : m_buses) {
+        i = 0;
+    }
+
+    for (auto &i : m_bridges_allocated) {
+        i = 0;
+    }
+}
+
+void
+device_allocator::enumerate(std::vector<device_id> &devices) const
+{
+    for (size_t bus = 0; bus <= 255; ++bus) {
+        for (device_type dev = 0; dev <= 31; ++dev) {
+            if ((m_buses[bus] & (1u << dev)) != 0) {
+                device_id device;
+                device.bus = gsl::narrow_cast<bus_type>(bus);
+                device.device = dev;
+                device.func = 0;
+                device.secondary_bus = secondary_bus_element(device.bus, device.device);
+                devices.push_back(device);
+            }
+        }
+    }
+}
+
+bus_type &
+device_allocator::secondary_bus_element(bus_type bus, device_type device)
+{
+    check_device(device);
+
+    size_t bus_extended = static_cast<size_t>(bus);
+    size_t dev_extended = static_cast<size_t>(device);
+
+    return m_bridges_allocated[(dev_extended << 8) | bus_extended];
+}
+
+bus_type
+device_allocator::secondary_bus_element(bus_type bus, device_type device) const
+{
+    check_device(device);
+
+    size_t bus_extended = static_cast<size_t>(bus);
+    size_t dev_extended = static_cast<size_t>(device);
+
+    return m_bridges_allocated[(dev_extended << 8) | bus_extended];
+}
+
+bus_type
+device_allocator::next_secondary() const
+{
+    for (size_t i = 1; i <= 255; ++i) {
+        bool found = false;
+
+        for (auto j : m_bridges_allocated) {
+            if (i == j) {
+                found = true;
+                break;
+            }
+        }
+
+        if (!found) {
+            return gsl::narrow_cast<bus_type>(i);
+        }
+    }
+
+    return 0;
+}
+
+void
+device_allocator::check_device(device_type device) const
+{
+    if (device > 31) {
+        throw std::logic_error("invalid PCI device number");
+    }
+}
+
+device_allocator::alloc_status
+device_allocator::check_add(device_id device) const
+{
+    check_device(device.device);
+
+    if (device.secondary_bus != 0) {
+        for (auto const &i : m_bridges_allocated) {
+            if (i == device.secondary_bus) {
+                return alloc_status::collision;
+            }
+        }
+
+        if (secondary_bus_element(device.bus, device.device) != 0) {
+            return alloc_status::collision;
+        }
+    }
+
+    if ((m_buses[device.bus] & (1u << device.device)) != 0) {
+        return alloc_status::collision;
+    }
+
+    return alloc_status::success;
+}

--- a/bfvmm/src/hve/phys_pci.cpp
+++ b/bfvmm/src/hve/phys_pci.cpp
@@ -39,7 +39,6 @@ static void enumerate_pci_one_device(std::vector<phys_pci> &vect, bus_type bus,
                                      device_type device);
 static void enumerate_pci_one_function(std::vector<phys_pci> &vect, bus_type bus,
                                        device_type device, func_type func);
-static bus_type get_secondary_bus(bus_type bus, device_type device, func_type func);
 
 void pci::phys_pci::enumerate(std::vector<phys_pci> &vect)
 {
@@ -96,18 +95,11 @@ static void enumerate_pci_one_function(std::vector<phys_pci> &vect, bus_type bus
     phys_pci pci_func(bus, device, func);
 
     if (pci_func.device_class() == 0x06 && pci_func.device_subclass() == 0x04) {
-        bus_type sec_bus = get_secondary_bus(bus, device, func);
+        bus_type sec_bus = pci_func.secondary_bus();
         enumerate_pci_one_bus(vect, sec_bus);
     }
 
     vect.push_back(pci_func);
-}
-
-static bus_type get_secondary_bus(bus_type bus, device_type device,
-                                  func_type func)
-{
-    phys_pci pci_func(bus, device, func);
-    return pci_func.read_register_u8(0x19);
 }
 
 enum bar::bar_type

--- a/bfvmm/tests/hve/CMakeLists.txt
+++ b/bfvmm/tests/hve/CMakeLists.txt
@@ -79,3 +79,8 @@ do_test(test_pci_register
     SOURCES arch/x64/test_pci_register.cpp
     ${ARGN}
 )
+
+do_test(test_pci_device_allocator
+    SOURCES test_pci_device_allocator.cpp
+    ${ARGN}
+)

--- a/bfvmm/tests/hve/arch/x64/pci_test_support.h
+++ b/bfvmm/tests/hve/arch/x64/pci_test_support.h
@@ -1,0 +1,172 @@
+//
+// Bareflank Extended APIs
+//
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+// We need a more complicated implementation of _ind and _outd
+// that implement PCI configuration space in a second map.
+#define _ind _simple_ind
+#define _outd _simple_outd
+#include <support/arch/intel_x64/test_support.h>
+#undef _ind
+#undef _outd
+
+#include <hve/phys_pci.h>
+
+#define PORTIO_CONFIG_ADDRESS   0xCF8
+#define PORTIO_CONFIG_DATA      0xCFC
+
+#define BAR_TEST_REGION_LENGTH  0x8000u
+
+#define DEVICE_1_2_3            0x80011300
+
+std::map<uint32_t, uint32_t> g_pci_config_space;
+
+static uint32_t intercept_bar_write(uint32_t addr, uint32_t value);
+
+extern "C" uint32_t
+_ind(uint16_t port) noexcept
+{
+    if (port == PORTIO_CONFIG_DATA) {
+        auto it = g_pci_config_space.find(g_ports[PORTIO_CONFIG_ADDRESS]);
+        if (it == g_pci_config_space.end()) {
+            return 0xFFFFFFFF;
+        }
+        else {
+            return it->second;
+        }
+    }
+    else {
+        return g_ports[port];
+    }
+}
+
+/// Modified test _outd with the following additional features:
+///
+/// - If writing to 0xCFC (PCI config data), redirect to a second map representing
+///   PCI config space.
+/// - If the PCI config space address represents a BAR, pass on to
+///   intercept_bar_write() to allow the region length query to be tested.
+extern "C" void
+_outd(uint16_t port, uint32_t value) noexcept
+{
+    if (port == PORTIO_CONFIG_DATA) {
+        uint32_t addr = g_ports[PORTIO_CONFIG_ADDRESS];
+        bool maybe_bar = (addr & 0xfc) >= 0x10 && (addr & 0xfc) <= 0x24;
+
+        uint32_t header_type_field = (addr & ~0xFCu) | 0x0Cu;
+        uint32_t header_type = (g_pci_config_space[header_type_field] & 0x007F0000u) >> 16;
+
+        g_pci_config_space[addr] = value;
+
+        if (maybe_bar) {
+            uint32_t bar_index = ((addr & 0xfc) - 0x10) / 4;
+
+            if ((header_type == 0 && bar_index <= 5) ||
+                (header_type == 1 && bar_index <= 1)) {
+
+                g_pci_config_space[addr] = intercept_bar_write(addr, value);
+            }
+        }
+    }
+
+    g_ports[port] = value;
+}
+
+static uint32_t
+intercept_bar_write(uint32_t addr, uint32_t value)
+{
+    if (value == 0xFFFFFFFF) {
+        if (addr & 0x4) {
+            // Odd BAR, assume second half of 64-bit
+            return 0xFFFFFFFF;
+        }
+        else {
+            uint32_t old_value = g_pci_config_space[addr];
+            return (~(BAR_TEST_REGION_LENGTH - 1u) & 0xFFFFFFFE) | (old_value & 0x1);
+        }
+    }
+    else {
+        return value;
+    }
+}
+
+static uint32_t
+reg_from_full_addr(uint32_t full_addr)
+{
+    return full_addr & 0xff;
+}
+
+static auto
+cleanup()
+{
+    return gsl::finally([&] {
+        g_ports.clear();
+        g_pci_config_space.clear();
+    });
+}
+
+static void
+init_all_config_space()
+{
+    for (uint32_t reg = 0; reg <= 0x3C; reg += 4) {
+        uint32_t addr = DEVICE_1_2_3 | reg;
+        g_pci_config_space[addr] = 0xaabbccdd;
+    }
+
+    g_ports[PORTIO_CONFIG_DATA] = 0xaabbccdd;
+}
+
+namespace eapis
+{
+namespace pci
+{
+
+TEST_CASE("pci_test_support")
+{
+    CHECK(reg_from_full_addr(0xaabbccdd) == 0xdd);
+    CHECK_NOTHROW(init_all_config_space());
+    CHECK(g_ports[PORTIO_CONFIG_DATA] == 0xaabbccdd);
+
+    CHECK_NOTHROW(_outd(1, 2));
+    CHECK(_ind(1) == 2);
+
+    CHECK_NOTHROW(_outd(PORTIO_CONFIG_ADDRESS, 0xABAD1DEA));
+    CHECK(_ind(PORTIO_CONFIG_DATA) == 0xFFFFFFFF);
+
+    // Set up a very simple header and check that BAR writes are intercepted
+    CHECK_NOTHROW(_outd(PORTIO_CONFIG_ADDRESS, 0x0000000C));
+    CHECK_NOTHROW(_outd(PORTIO_CONFIG_DATA,    0x00000000));
+    CHECK_NOTHROW(_outd(PORTIO_CONFIG_ADDRESS, 0x00000010));
+    CHECK_NOTHROW(_outd(PORTIO_CONFIG_DATA,    0xFFFFFFFF));
+    CHECK(_ind(PORTIO_CONFIG_DATA) != 0xFFFFFFFF);
+
+    for (uint32_t reg = 0; reg <= 0x3C; reg += 4) {
+        CHECK(g_pci_config_space[DEVICE_1_2_3 | reg] == 0xaabbccdd);
+    }
+
+    {
+        auto ___ = cleanup();
+    }
+
+    CHECK(g_pci_config_space[DEVICE_1_2_3] == 0);
+
+}
+
+}
+
+}

--- a/bfvmm/tests/hve/test_pci_device_allocator.cpp
+++ b/bfvmm/tests/hve/test_pci_device_allocator.cpp
@@ -1,0 +1,240 @@
+//
+// Bareflank Extended APIs
+//
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <intrinsics.h>
+
+#include "arch/x64/pci_test_support.h"
+#include <hve/pci_device_allocator.h>
+
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
+namespace eapis
+{
+namespace pci
+{
+
+TEST_CASE("Empty device_allocator")
+{
+    std::vector<device_id> enumerated;
+    device_allocator alloc;
+
+    CHECK_NOTHROW(alloc.enumerate(enumerated));
+    CHECK(enumerated.empty());
+}
+
+TEST_CASE("device_allocator::add,contains,deallocate,clear")
+{
+    device_id device = { 1, 2, 3, 0 };
+    device_allocator alloc;
+
+    CHECK(!alloc.contains(device));
+    CHECK(alloc.add(device) == device_allocator::alloc_status::success);
+    CHECK(alloc.contains(device));
+    CHECK(alloc.add(device) == device_allocator::alloc_status::collision);
+    CHECK(alloc.contains(device));
+
+    CHECK_NOTHROW(alloc.deallocate(device));
+    CHECK(!alloc.contains(device));
+    CHECK(alloc.add(device) == device_allocator::alloc_status::success);
+    CHECK(alloc.contains(device));
+
+    CHECK_NOTHROW(alloc.clear());
+    CHECK(!alloc.contains(device));
+}
+
+TEST_CASE("device_allocator::populate_from")
+{
+    device_id device = { 1, 2, 3, 0 };
+    device_allocator alloc1, alloc2;
+
+    CHECK(alloc1.add(device) == device_allocator::alloc_status::success);
+    CHECK(alloc2.populate_from(alloc1) == device_allocator::alloc_status::success);
+    CHECK(alloc2.contains(device));
+    CHECK(alloc2.populate_from(alloc1) == device_allocator::alloc_status::collision);
+    CHECK(alloc2.contains(device));
+    CHECK(alloc1.populate_from(alloc1) == device_allocator::alloc_status::collision);
+    CHECK(alloc1.contains(device));
+}
+
+TEST_CASE("device_allocator::allocate(device_id &),allocate_bridge(device_id &)")
+{
+    device_id device1, device2;
+    device_allocator alloc;
+
+    CHECK(alloc.allocate(device1) == device_allocator::alloc_status::success);
+    CHECK(device1.bus == 0);
+    CHECK(device1.device == 0);
+    CHECK(device1.func == 0);
+    CHECK(device1.secondary_bus == 0);
+    CHECK(alloc.contains(device1));
+
+    CHECK(alloc.allocate(device2) == device_allocator::alloc_status::success);
+    CHECK(device2.bus == 0);
+    CHECK(device2.device == 1);
+    CHECK(device2.func == 0);
+    CHECK(device2.secondary_bus == 0);
+    CHECK(alloc.contains(device2));
+    CHECK(alloc.contains(device1));
+
+    alloc.clear();
+
+    for (int i = 0; i <= 30; ++i) {
+        CHECK(alloc.allocate(device1) == device_allocator::alloc_status::success);
+    }
+
+    CHECK(alloc.allocate(device1) == device_allocator::alloc_status::bus_almost_full);
+
+    device_id bridge;
+    CHECK(alloc.allocate_bridge(bridge) == device_allocator::alloc_status::success);
+    CHECK(alloc.contains(bridge));
+    CHECK(bridge.bus == 0);
+    CHECK(bridge.device == 31);
+    CHECK(bridge.func == 0);
+    CHECK(bridge.secondary_bus == 1);
+
+    CHECK(alloc.allocate(device1) == device_allocator::alloc_status::success);
+    CHECK(alloc.contains(device1));
+    CHECK(device1.bus == 1);
+}
+
+TEST_CASE("device_allocator::allocate(bus_type, device_id &)")
+{
+    device_id device;
+    device_allocator alloc;
+
+    for (int i = 0; i <= 30; ++i) {
+        CHECK(alloc.allocate(0, device) == device_allocator::alloc_status::success);
+        CHECK(device.bus == 0);
+        CHECK(device.device == i);
+    }
+
+    device_id bridge;
+    CHECK(alloc.allocate_bridge(bridge) == device_allocator::alloc_status::success);
+
+    CHECK(alloc.allocate(0, device) == device_allocator::alloc_status::bus_full);
+    CHECK(alloc.allocate(1, device) == device_allocator::alloc_status::success);
+
+    CHECK(device.bus == 1);
+
+}
+
+TEST_CASE("device_allocator::allocate_bridge(bus_type, device_id &)")
+{
+    device_id device;
+    device_allocator alloc;
+
+    for (int i = 0; i <= 30; ++i) {
+        CHECK(alloc.allocate(0, device) == device_allocator::alloc_status::success);
+        CHECK(device.bus == 0);
+        CHECK(device.device == i);
+    }
+
+    device_id bridge1, bridge2;
+    CHECK(alloc.allocate_bridge(bridge1) == device_allocator::alloc_status::success);
+
+    CHECK(alloc.allocate_bridge(0, bridge2) == device_allocator::alloc_status::bus_full);
+    CHECK(alloc.allocate_bridge(1, bridge2) == device_allocator::alloc_status::success);
+    CHECK(bridge1.bus == 0);
+    CHECK(bridge1.secondary_bus == 1);
+    CHECK(bridge2.bus == 1);
+    CHECK(bridge2.secondary_bus == 2);
+}
+
+TEST_CASE("device_allocator::enumerate")
+{
+    std::vector<device_id> devices_in;
+    std::vector<device_id> devices_out;
+    device_id bridge;
+    device_allocator alloc;
+
+    for (size_t i = 0; i < 10; ++i) {
+        device_id device;
+        CHECK(alloc.allocate(device) == device_allocator::alloc_status::success);
+        devices_in.push_back(device);
+    }
+
+    CHECK(alloc.allocate_bridge(bridge) == device_allocator::alloc_status::success);
+    devices_in.push_back(bridge);
+
+    CHECK_NOTHROW(alloc.enumerate(devices_out));
+    CHECK(devices_in.size() == devices_out.size());
+
+    for (size_t i = 0; i < devices_in.size(); ++i) {
+        CHECK(devices_in[i].bus == devices_out[i].bus);
+        CHECK(devices_in[i].device == devices_out[i].device);
+        CHECK(devices_in[i].func == devices_out[i].func);
+        CHECK(devices_in[i].secondary_bus == devices_out[i].secondary_bus);
+    }
+}
+
+TEST_CASE("device_allocator::populate_physical")
+{
+    auto ___ = cleanup();
+
+    // Generate a few devices
+    write_register(0, 0, 0, 0x00, 0x12345678);  // vendor, device
+    write_register(0, 0, 0, 0x08, 0x00000000);  // class
+    write_register(0, 0, 0, 0x0C, 0x00000000);  // header type
+
+    write_register(0, 1, 0, 0x00, 0x12345678);  // vendor, device
+    write_register(0, 1, 0, 0x08, 0x00000000);  // class
+    write_register(0, 1, 0, 0x0C, 0x00000000);  // header type
+
+    // A bridge
+    write_register(0, 2, 0, 0x00, 0x12345678);  // vendor, device
+    write_register(0, 2, 0, 0x08, 0x06040000);  // class
+    write_register(0, 2, 0, 0x0C, 0x00010000);  // header type
+    write_register(0, 2, 0, 0x18, 0x00000100);  // secondary bus
+
+    write_register(1, 0, 0, 0x00, 0x12345678);  // vendor, device
+    write_register(1, 0, 0, 0x08, 0x00000000);  // class
+    write_register(1, 0, 0, 0x0C, 0x00000000);  // header type
+
+    device_allocator alloc;
+    std::vector<device_id> devices;
+
+    CHECK_NOTHROW(alloc.populate_physical());
+    CHECK_NOTHROW(alloc.enumerate(devices));
+
+    CHECK(devices.size() == 4);
+    CHECK(devices[0].bus == 0);
+    CHECK(devices[0].device == 0);
+    CHECK(devices[0].func == 0);
+    CHECK(devices[0].secondary_bus == 0);
+
+    CHECK(devices[1].bus == 0);
+    CHECK(devices[1].device == 1);
+    CHECK(devices[1].func == 0);
+    CHECK(devices[1].secondary_bus == 0);
+
+    CHECK(devices[2].bus == 0);
+    CHECK(devices[2].device == 2);
+    CHECK(devices[2].func == 0);
+    CHECK(devices[2].secondary_bus == 1);
+
+    CHECK(devices[3].bus == 1);
+    CHECK(devices[3].device == 0);
+    CHECK(devices[3].func == 0);
+    CHECK(devices[3].secondary_bus == 0);
+}
+
+}
+}
+
+#endif


### PR DESCRIPTION
`pci_device_allocator` is a class for allocating geographical PCI device addresses for both physical and virtual uses. This PR also adds pci_test_support.h into which the test support code for PCI (emulation of config space via ports `0xCF8` and `0xCFC`) has been moved.

Signed-off-by: Chris Pavlina <pavlinac@ainfosec.com>