### PR TITLE
Use size_t instead of uintptr_t for sizes

### DIFF
--- a/bfvmm/include/hve/phys_pci.h
+++ b/bfvmm/include/hve/phys_pci.h
@@ -396,7 +396,7 @@ public:
     /// @brief Get the length of this BAR's memory region.
     /// This is not const because it must write to the BAR to query.
     /// @return memory/IO region length in bytes
-    uintptr_t region_length();
+    size_t region_length();
 
     /// @brief Get whether this region is prefetchable.
     /// Always returns false for IO BARs.
@@ -422,7 +422,7 @@ private:
     enum bar_type compute_type() const;
 
     /// Compute the memory region length for 64-bit only
-    uintptr_t region_length_64();
+    size_t region_length_64();
 
     /// Return the bitmask of address bits for this BAR type
     uint32_t mask() const;

--- a/bfvmm/src/hve/phys_pci.cpp
+++ b/bfvmm/src/hve/phys_pci.cpp
@@ -181,7 +181,7 @@ bar::base_address() const
     return addr;
 }
 
-uintptr_t
+size_t
 bar::region_length()
 {
     if (m_type == bar_memory_64bit) {
@@ -196,7 +196,7 @@ bar::region_length()
     uint32_t region_bits = m_device.bar(m_index);
     m_device.set_bar(m_index, orig_contents);
 
-    uintptr_t len = ~(0xFFFFFFFF00000000uLL | static_cast<uintptr_t>(region_bits & mask())) + 1uLL;
+    size_t len = ~(0xFFFFFFFF00000000uLL | static_cast<size_t>(region_bits & mask())) + 1uLL;
 
     if (m_type == bar_io) {
         len &= 0xFFFF;
@@ -205,7 +205,7 @@ bar::region_length()
     return len;
 }
 
-uintptr_t
+size_t
 bar::region_length_64()
 {
     uint32_t orig_contents[2] = {
@@ -228,7 +228,7 @@ bar::region_length_64()
     const uint64_t merged = static_cast<uint64_t>(region_bits[0]) | (static_cast<uint64_t>(region_bits[1]) << 32);
     const uint64_t masked = merged & mask;
 
-    return static_cast<uintptr_t>(~masked + 1);
+    return static_cast<size_t>(~masked + 1);
 }
 
 bool


### PR DESCRIPTION
Signed-off-by: Chris Pavlina <pavlinac@ainfosec.com>