### PR TITLE
IOAPIC intrinsics and both phys and virt classes

### DIFF
--- a/bfvmm/include/hve/arch/intel_x64/phys_ioapic.h
+++ b/bfvmm/include/hve/arch/intel_x64/phys_ioapic.h
@@ -1,0 +1,128 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef PHYS_IOAPIC_INTEL_X64_EAPIS_H
+#define PHYS_IOAPIC_INTEL_X64_EAPIS_H
+
+#include <cstdint>
+#include <arch/intel_x64/apic/ioapic.h>
+#include "base.h"
+
+namespace eapis
+{
+namespace intel_x64
+{
+
+/// Physical IOAPIC
+///
+/// Provides an interface for reading and writing a physical ioapic.
+///
+class EXPORT_EAPIS_HVE phys_ioapic
+{
+public:
+
+    /// Default Constructor
+    ///
+    /// @expects (base != 0) && ::intel_x64::ioapic::align_base(base) == base
+    /// @ensures
+    ///
+    /// @param base the base address of the ioapic
+    ///
+    phys_ioapic(::intel_x64::ioapic::base_t base);
+
+    /// Destructor
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    ~phys_ioapic() = default;
+
+    /// Base
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @return the base address of the physical ioapic
+    ///
+    ::intel_x64::ioapic::base_t base() const;
+
+    /// Relocate
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @param base the new base address of the ioapic
+    ///
+    void relocate(::intel_x64::ioapic::base_t base);
+
+    /// Read
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @return the value of the register at the pre-select()'d
+    ///         offset
+    ///
+    ::intel_x64::ioapic::value_t read();
+
+    /// Write
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @param val the 32-bit value to write to the pre-select()'d
+    ///        offset
+    ///
+    void write(::intel_x64::ioapic::value_t val);
+
+    /// Select
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @param offset the register offset to select
+    ///
+    void select(::intel_x64::ioapic::offset_t offset);
+
+    /// @cond
+
+private:
+
+    void set_ioregsel(::intel_x64::ioapic::offset_t offset);
+    void set_ioregwin(::intel_x64::ioapic::value_t val);
+
+    ::intel_x64::ioapic::value_t get_ioregsel() const;
+    ::intel_x64::ioapic::value_t get_ioregwin() const;
+
+    ::intel_x64::ioapic::base_t m_base;
+
+public:
+
+    phys_ioapic(phys_ioapic &&) = default;
+    phys_ioapic &operator=(phys_ioapic &&) = default;
+
+    phys_ioapic(const phys_ioapic &) = delete;
+    phys_ioapic &operator=(const phys_ioapic &) = delete;
+
+    /// @endcond
+};
+
+}
+}
+
+#endif

--- a/bfvmm/include/hve/arch/intel_x64/virt_ioapic.h
+++ b/bfvmm/include/hve/arch/intel_x64/virt_ioapic.h
@@ -1,0 +1,121 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef VIRT_IOAPIC_INTEL_X64_EAPIS_H
+#define VIRT_IOAPIC_INTEL_X64_EAPIS_H
+
+#include <array>
+#include <arch/intel_x64/apic/ioapic.h>
+#include "phys_ioapic.h"
+
+namespace eapis
+{
+namespace intel_x64
+{
+
+class hve;
+class phys_ioapic;
+
+///
+/// Virtual IOAPIC
+///
+class EXPORT_EAPIS_HVE virt_ioapic
+{
+public:
+
+    /// Constructor
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    virt_ioapic();
+
+    /// Constructor from physical IOAPIC
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @param phys the phys_ioapic object for this physical core
+    ///
+    virt_ioapic(gsl::not_null<eapis::intel_x64::phys_ioapic *> phys);
+
+    /// Destructor
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    ~virt_ioapic() = default;
+
+    /// Read
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @return the value of the 32-bit register given by the
+    ///         previously select()'d register
+    ///
+    ::intel_x64::ioapic::value_t read() const;
+
+    /// Write
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @param val the 32-bit value to write to the previously
+    ///        select()'d register
+    ///
+    void write(::intel_x64::ioapic::value_t val);
+
+    /// Select
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    /// @param offset the register offset to select for reading or writing
+    ///
+    void select(::intel_x64::ioapic::offset_t offset);
+
+#ifndef ENABLE_BUILD_TEST
+private:
+#endif
+
+    /// @cond
+
+    ::intel_x64::ioapic::offset_t m_select;
+    std::array<::intel_x64::ioapic::value_t, ::intel_x64::ioapic::rte_end> m_reg;
+
+    /// @endcond
+
+public:
+
+    /// @cond
+
+    virt_ioapic(virt_ioapic &&) = default;
+    virt_ioapic &operator=(virt_ioapic &&) = default;
+
+    virt_ioapic(const virt_ioapic &) = delete;
+    virt_ioapic &operator=(const virt_ioapic &) = delete;
+
+    /// @endcond
+};
+
+
+}
+}
+
+#endif

--- a/bfvmm/src/hve/CMakeLists.txt
+++ b/bfvmm/src/hve/CMakeLists.txt
@@ -28,8 +28,10 @@ if(${BUILD_TARGET_ARCH} STREQUAL "x86_64")
         arch/intel_x64/io_instruction.cpp
         arch/intel_x64/isr.cpp
         arch/intel_x64/lapic_register.cpp
+        arch/intel_x64/phys_ioapic.cpp
         arch/intel_x64/phys_xapic.cpp
         arch/intel_x64/phys_x2apic.cpp
+        arch/intel_x64/virt_ioapic.cpp
         arch/intel_x64/virt_lapic.cpp
         arch/intel_x64/monitor_trap.cpp
         arch/intel_x64/mov_dr.cpp

--- a/bfvmm/src/hve/arch/intel_x64/phys_ioapic.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/phys_ioapic.cpp
@@ -1,0 +1,102 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <arch/intel_x64/apic/ioapic.h>
+#include <hve/arch/intel_x64/phys_ioapic.h>
+
+namespace eapis
+{
+namespace intel_x64
+{
+
+namespace ioapic = ::intel_x64::ioapic;
+
+phys_ioapic::phys_ioapic(ioapic::base_t base)
+{
+    expects(base != 0U);
+    expects(base == ioapic::align_base(base));
+
+    m_base = base;
+}
+
+ioapic::base_t
+phys_ioapic::base() const
+{ return m_base; }
+
+void
+phys_ioapic::relocate(ioapic::base_t base)
+{
+    expects(base != 0U);
+    expects(base == ioapic::align_base(base));
+
+    m_base = base;
+}
+
+ioapic::value_t
+phys_ioapic::read()
+{ return this->get_ioregwin(); }
+
+void
+phys_ioapic::write(ioapic::value_t val)
+{
+    const auto sel = gsl::narrow_cast<ioapic::offset_t>(this->get_ioregsel());
+    expects(ioapic::is_writable(sel));
+    this->set_ioregwin(val);
+}
+
+void
+phys_ioapic::select(ioapic::offset_t offset)
+{
+    expects(ioapic::exists(offset));
+    this->set_ioregsel(offset);
+}
+
+void
+phys_ioapic::set_ioregsel(ioapic::offset_t offset)
+{
+    constexpr auto sel_offset = 0x00U;
+    auto addr = reinterpret_cast<ioapic::value_t *>(m_base + sel_offset);
+    *addr = offset;
+}
+
+ioapic::value_t
+phys_ioapic::get_ioregsel() const
+{
+    constexpr auto sel_offset = 0x00U;
+    auto addr = reinterpret_cast<ioapic::value_t *>(m_base + sel_offset);
+    return *addr;
+}
+
+void
+phys_ioapic::set_ioregwin(ioapic::value_t val)
+{
+    constexpr auto win_offset = 0x10U;
+    auto addr = reinterpret_cast<ioapic::value_t *>(m_base + win_offset);
+    *addr = val;
+}
+
+ioapic::value_t
+phys_ioapic::get_ioregwin() const
+{
+    constexpr auto win_offset = 0x10U;
+    auto addr = reinterpret_cast<ioapic::value_t *>(m_base + win_offset);
+    return *addr;
+}
+
+}
+}

--- a/bfvmm/src/hve/arch/intel_x64/virt_ioapic.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/virt_ioapic.cpp
@@ -1,0 +1,80 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <arch/intel_x64/apic/ioapic.h>
+#include <hve/arch/intel_x64/virt_ioapic.h>
+
+namespace eapis
+{
+namespace intel_x64
+{
+
+namespace ioapic = ::intel_x64::ioapic;
+
+virt_ioapic::virt_ioapic() :
+    m_select{0U}
+{
+    /// Init registers 0-2
+    m_reg.at(ioapic::id::offset) = ioapic::id::default_val;
+    m_reg.at(ioapic::ver::offset) = ioapic::ver::default_val;
+    m_reg.at(ioapic::arb::offset) = ioapic::arb::default_val;
+
+    /// Init registers 16-63 (RTEs)
+    for (ioapic::offset_t i = ioapic::rte_begin; i < ioapic::rte_end; ++i) {
+        m_reg.at(i) = gsl::narrow_cast<uint32_t>(ioapic::rte::mask_bit::enable(0U));
+    }
+}
+
+virt_ioapic::virt_ioapic(gsl::not_null<eapis::intel_x64::phys_ioapic *> phys) :
+    m_select{0U}
+{
+    ::x64::rflags::interrupt_enable_flag::disable();
+
+    for (ioapic::offset_t i = 0x0U; i < ioapic::rte_end; ++i) {
+        if (!ioapic::exists(i)) {
+            m_reg.at(i) = 0U;
+            continue;
+        }
+
+        phys->select(i);
+        m_reg.at(i) = phys->read();
+    }
+
+    ::x64::rflags::interrupt_enable_flag::enable();
+}
+
+ioapic::value_t
+virt_ioapic::read() const
+{ return m_reg.at(m_select); }
+
+void
+virt_ioapic::write(ioapic::value_t val)
+{
+    expects(ioapic::is_writable(m_select));
+    m_reg.at(m_select) = val;
+}
+
+void
+virt_ioapic::select(ioapic::offset_t offset)
+{
+    expects(ioapic::exists(offset));
+    m_select = offset;
+}
+
+}
+}

--- a/bfvmm/tests/hve/CMakeLists.txt
+++ b/bfvmm/tests/hve/CMakeLists.txt
@@ -51,6 +51,16 @@ do_test(test_vpid
     ${ARGN}
 )
 
+do_test(test_phys_ioapic
+    SOURCES arch/intel_x64/test_phys_ioapic.cpp
+    ${ARGN}
+)
+
+do_test(test_virt_ioapic
+    SOURCES arch/intel_x64/test_virt_ioapic.cpp
+    ${ARGN}
+)
+
 do_test(test_phys_xapic
     SOURCES arch/intel_x64/test_phys_xapic.cpp
     ${ARGN}

--- a/bfvmm/tests/hve/arch/intel_x64/test_phys_ioapic.cpp
+++ b/bfvmm/tests/hve/arch/intel_x64/test_phys_ioapic.cpp
@@ -1,0 +1,67 @@
+//
+// Bareflank Extended APIs
+//
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <hve/arch/intel_x64/hve.h>
+#include <arch/intel_x64/apic/ioapic.h>
+#include <hve/arch/intel_x64/phys_ioapic.h>
+#include <support/arch/intel_x64/test_support.h>
+
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
+namespace eapis
+{
+namespace intel_x64
+{
+
+alignas(16) uint32_t
+g_ioapic[0x40U] = {0U};
+uintptr_t g_base = reinterpret_cast<uintptr_t>(g_ioapic);
+
+namespace ioapic = ::intel_x64::ioapic;
+
+TEST_CASE("phys_ioapic")
+{
+    auto ioapic = phys_ioapic(0xFEC00000U);
+    CHECK(ioapic.base() == 0xFEC00000U);
+    CHECK_NOTHROW(ioapic.relocate(g_base));
+    CHECK_THROWS(ioapic.select(0xFFU));
+
+    for (ioapic::offset_t i = 0U; i < ioapic::rte_end; ++i) {
+        if (eapis::intel_x64::ioapic::is_writable(i)) {
+            CHECK_NOTHROW(ioapic.select(i));
+            CHECK_NOTHROW(ioapic.write(0xFFFFFFFFU));
+            CHECK(eapis::intel_x64::ioapic::is_readable(i));
+            CHECK_NOTHROW(ioapic.read() == 0xFFFFFFFFU);
+            continue;
+        }
+
+        if (eapis::intel_x64::ioapic::is_read_only(i)) {
+            CHECK_NOTHROW(ioapic.select(i));
+            CHECK_THROWS(ioapic.write(0U));
+            continue;
+        }
+
+        CHECK_FALSE(eapis::intel_x64::ioapic::exists(i));
+    }
+}
+
+}
+}
+
+#endif

--- a/bfvmm/tests/hve/arch/intel_x64/test_virt_ioapic.cpp
+++ b/bfvmm/tests/hve/arch/intel_x64/test_virt_ioapic.cpp
@@ -1,0 +1,62 @@
+//
+// Bareflank Extended APIs
+//
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <hve/arch/intel_x64/hve.h>
+#include <arch/intel_x64/apic/ioapic.h>
+#include <hve/arch/intel_x64/virt_ioapic.h>
+#include <support/arch/intel_x64/test_support.h>
+
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
+namespace eapis
+{
+namespace intel_x64
+{
+
+namespace ioapic = ::intel_x64::ioapic;
+
+TEST_CASE("virt_ioapic")
+{
+    auto virt = virt_ioapic();
+
+    virt.select(ioapic::id::offset);
+    CHECK(virt.read() == ioapic::id::default_val);
+
+    virt.select(ioapic::ver::offset);
+    CHECK(virt.read() == ioapic::ver::default_val);
+
+    virt.select(ioapic::arb::offset);
+    CHECK(virt.read() == ioapic::arb::default_val);
+
+    for (ioapic::offset_t i = 3U; i < ioapic::rte_begin; ++i) {
+        CHECK_THROWS(virt.select(i));
+    }
+
+    for (ioapic::offset_t i = ioapic::rte_begin; i < ioapic::rte_end; ++i) {
+        CHECK_NOTHROW(virt.select(i));
+        CHECK_NOTHROW(virt.read() == ioapic::rte::mask_bit::enable(0U));
+        virt.write(0ULL);
+        CHECK(ioapic::rte::mask_bit::is_disabled(virt.read()));
+    }
+}
+
+}
+}
+
+#endif


### PR DESCRIPTION
The register space of the IOAPIC is described in Chapter 3 of
the IOAPIC specification. Its registers may be accessed with 32-bit
loads and stores offset from the base address derived from the ACPI
tables (which defaults to 0xFEC00000).

- Add phys_ioapic class to interact with the physical IOAPIC
- Add virt_ioapic class to interact with virtual IOAPICs
- Add corresponding unit tests

The current implementation provides only basic read/write capabilities
A future iteration is planned to provide more complex logic
(e.g. virtual routing) as needed.

Signed-off-by: Connor Davis <davisc@ainfosec.com>