### PR TITLE
Fix cmake project setttings

### DIFF
--- a/bfsdk/tests/CMakeLists.txt
+++ b/bfsdk/tests/CMakeLists.txt
@@ -21,7 +21,7 @@ project(eapis_bfsdk_test C CXX)
 
 include(${SOURCE_CMAKE_DIR}/project.cmake)
 init_project(
-    INCLUDES ${CMAKE_CURRENT_LIST_DIR}/../include
+    INCLUDES ${PROJECT_SOURCE_DIR}/../include
 )
 
 do_test(test_capstone)

--- a/bfvmm/src/CMakeLists.txt
+++ b/bfvmm/src/CMakeLists.txt
@@ -21,8 +21,8 @@ project(eapis C CXX)
 
 include(${SOURCE_CMAKE_DIR}/project.cmake)
 init_project(
-    INCLUDES ${CMAKE_CURRENT_LIST_DIR}/../include
-    INCLUDES ${CMAKE_CURRENT_LIST_DIR}/../../bfsdk/include
+    INCLUDES ${PROJECT_SOURCE_DIR}/../include
+    INCLUDES ${PROJECT_SOURCE_DIR}/../../bfsdk/include
 )
 
 add_subdirectory(hve)
@@ -32,3 +32,4 @@ add_subdirectory(hve)
 # -----------------------------------------------------------------------------
 
 install(DIRECTORY ../include/ DESTINATION include/eapis)
+install(DIRECTORY ../../bfsdk/include/ DESTINATION include/)

--- a/bfvmm/src/hve/CMakeLists.txt
+++ b/bfvmm/src/hve/CMakeLists.txt
@@ -65,6 +65,7 @@ list(APPEND SOURCES
 
 add_shared_library(
     eapis_hve
+    DEPENDS capstone
     SOURCES ${SOURCES}
     DEFINES SHARED_EAPIS_HVE
     DEFINES SHARED_HVE
@@ -74,6 +75,7 @@ add_shared_library(
 
 add_static_library(
     eapis_hve
+    DEPENDS capstone
     SOURCES ${SOURCES}
     DEFINES STATIC_EAPIS_HVE
     DEFINES STATIC_HVE

--- a/bfvmm/tests/CMakeLists.txt
+++ b/bfvmm/tests/CMakeLists.txt
@@ -21,8 +21,8 @@ project(eapis_test C CXX)
 
 include(${SOURCE_CMAKE_DIR}/project.cmake)
 init_project(
-    INCLUDES ${CMAKE_CURRENT_LIST_DIR}/../include
-    INCLUDES ${CMAKE_CURRENT_LIST_DIR}/../../bfsdk/include
+    INCLUDES ${PROJECT_SOURCE_DIR}/../include
+    INCLUDES ${PROJECT_SOURCE_DIR}/../../bfsdk/include
 )
 
 add_subdirectory(../src/hve ${CMAKE_CURRENT_BINARY_DIR}/src/hve)
@@ -35,3 +35,4 @@ add_subdirectory(support)
 # -----------------------------------------------------------------------------
 
 install(DIRECTORY ../include/ DESTINATION include/eapis)
+install(DIRECTORY ../../bfsdk/include/ DESTINATION include)


### PR DESCRIPTION
- Ensure the bfsdk headers (now only bfcapstone.h) need to be installed
  in the test and vmm prefix

- Use PROJECT_SOURCE_DIR rather than CMAKE_CURRENT_LIST_DIR so that the
  include paths remain relative to the extended APIs when downstream
  projects consume them

Signed-off-by: Connor Davis <davisc@ainfosec.com>