### PR TITLE
EAPIs Capstone Dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,12 +22,14 @@ include(${CMAKE_CURRENT_LIST_DIR}/scripts/cmake/depends/capstone.cmake)
 if(ENABLE_BUILD_VMM)
     vmm_extension(
         eapis
+        DEPENDS capstone
         SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bfvmm/src
     )
 
     vmm_extension(
         eapis_main
         DEPENDS eapis
+        DEPENDS capstone
         SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bfvmm/src/main
     )
 


### PR DESCRIPTION
When building with `make` instead of `make -j#`, the EAPIs BFSDK code was unable to locate capstone files. We add capstone as dependencies to the two EAPIS BFVMM src projects to fix this issue.