### PR TITLE
Add phys_mtrr class

### DIFF
--- a/bfvmm/include/hve/arch/intel_x64/mtrr.h
+++ b/bfvmm/include/hve/arch/intel_x64/mtrr.h
@@ -1,0 +1,221 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef MTRR_INTEL_X64_EAPIS_H
+#define MTRR_INTEL_X64_EAPIS_H
+
+#include <cstdint>
+#include <arch/x64/misc.h>
+#include <arch/intel_x64/mtrr.h>
+#include "base.h"
+#include "hve.h"
+
+namespace eapis
+{
+namespace intel_x64
+{
+namespace mtrr
+{
+
+/// MTRR range
+///
+/// This structure provides an abstraction over the MTRR ranges
+/// Users don't need to care whether the range described by an
+/// instance of this is fixed, variable, or a combination of both
+///
+struct range
+{
+    /// base the base address of the range
+    uintptr_t base;
+
+    /// size the number of bytes in the range
+    uint64_t size;
+
+    /// type the memory type of this range
+    uint64_t type;
+};
+
+/// Page frame number mask (for 4K pages)
+constexpr uint64_t pfn_mask_4k = ~(0x1000U - 1U);
+
+/// Extract the mask from an ia32_physmask{n} msr
+///
+/// @param mask_msr the value of the ia32_physmask msr
+/// @param pas the number of physical address bits
+///
+inline uint64_t mask_msr_to_mask(uint64_t mask_msr, uint64_t pas)
+{
+    const uint64_t from = ::intel_x64::mtrr::ia32_physmask::physmask::from;
+    return ::intel_x64::mtrr::ia32_physmask::physmask::get(mask_msr, pas) << from;
+}
+
+/// Extract the size of a range from an ia32_physmask{n} msr
+///
+/// @param mask_msr the value of the ia32_physmask msr
+/// @param pas the number of physical address bits
+///
+inline uint64_t mask_msr_to_size(uint64_t mask_msr, uint64_t pas)
+{
+    const uint64_t bits = ((1ULL << pas) - 1U);
+    const uint64_t mask = mask_msr_to_mask(mask_msr, pas);
+    return (~mask & bits) + 1U;
+}
+
+/// Extract the base of the range from an ia32_physbase{n} msr
+///
+/// @param base_msr the value of the ia32_physbase msr
+/// @param pas the number of physical address bits
+///
+inline uint64_t base_msr_to_base(uint64_t base_msr, uint64_t pas)
+{
+    const uint64_t from = ::intel_x64::mtrr::ia32_physbase::physbase::from;
+    return ::intel_x64::mtrr::ia32_physbase::physbase::get(base_msr, pas) << from;
+}
+
+/// base_msr_to_type
+///
+/// Extract the type of the range from an ia32_physbase{n} msr
+///
+/// @param base_msr the value of the ia32_physbase msr
+/// @param pas the number of physical address bits
+///
+inline uint64_t base_msr_to_type(uint64_t base_msr)
+{ return ::intel_x64::mtrr::ia32_physbase::type::get(base_msr); }
+
+/// size_to_mask
+///
+/// Convert the range size to the corresponding mask
+///
+/// @param size the size of the range
+/// @param pas the number of bits in a physical address
+//
+/// @return the mask that determines the set of addresses that
+///         lie in the range
+/// @note @param size should be the value returned from mask_msr_to_size
+///
+constexpr inline uint64_t size_to_mask(uint64_t size, uint64_t pas)
+{
+    const uint64_t bits = ((1ULL << pas) - 1U);
+    return ~(size - 1U) & bits;
+}
+
+/// mask_to_size
+///
+/// Convert the range mask to the corresponding size
+///
+/// @param mask the mask of the range
+/// @param pas the number of bits in a physical address
+//
+/// @return the mask that determines the set of addresses that
+///         lie in the range
+/// @note @param mask should be the value returned from mask_msr_to_mask
+///
+constexpr inline uint64_t mask_to_size(uint64_t mask, uint64_t pas)
+{
+    const uint64_t bits = ((1ULL << pas) - 1U);
+    return (~mask & bits) + 1U;
+}
+
+/// Variable MTRR range
+///
+///
+struct variable_range {
+
+    /// Constructor
+    ///
+    /// Create a variable range from the physbase and physmask
+    /// msr values provided. Note that the values are checked to
+    /// ensure that any struct variable_range this is created is valid.
+    ///
+    /// @param base_msr the value of the ia32_physbase msr
+    /// @param mask_msr the value of the ia32_physmask msr
+    /// @param pas the number of physical address bits
+    ///
+    variable_range(uint64_t base_msr, uint64_t mask_msr, uint64_t pas)
+    {
+        const uint64_t type = base_msr_to_type(base_msr);
+        const uint64_t base = base_msr_to_base(base_msr, pas);
+        const uint64_t size = mask_msr_to_size(mask_msr, pas);
+        constexpr uint64_t min_size = 0x1000U;
+
+        expects(pas >= 39U && pas <= 52U);
+        expects(::intel_x64::mtrr::valid_type(type));
+        expects(x64::is_physical_address_valid(base, pas));
+        expects(size >= min_size);
+        expects(base >= size);
+        expects((size & (size - 1U)) == 0U);
+        expects((base & (size - 1U)) == 0U);
+        expects((base + size) > base);
+
+        m_base_msr = base_msr;
+        m_mask_msr = mask_msr;
+        m_pas = pas;
+    }
+
+    /// size
+    ///
+    /// @return the number of bytes in the range
+    ///
+    uint64_t size() const
+    { return mask_msr_to_size(m_mask_msr, m_pas); }
+
+    /// type
+    ///
+    /// @return the memory type of the range
+    ///
+    uint64_t type() const
+    { return base_msr_to_type(m_base_msr); }
+
+    /// base
+    ///
+    /// @return the base address
+    ///
+    uint64_t base() const
+    { return base_msr_to_base(m_base_msr, m_pas); }
+
+    /// mask
+    ///
+    /// @return the range mask
+    ///
+    uint64_t mask() const
+    { return mask_msr_to_mask(m_mask_msr, m_pas); }
+
+    /// contains
+    ///
+    /// @param addr the address to check
+    /// @return true iff the range contains the given address
+    ///
+    bool contains(uintptr_t addr) const
+    {
+        const uint64_t base = base_msr_to_base(m_base_msr, m_pas);
+        const uint64_t mask = mask_msr_to_mask(m_mask_msr, m_pas);
+        return (mask & base) == (mask & addr);
+    }
+
+private:
+
+    uint64_t m_base_msr;
+    uint64_t m_mask_msr;
+    uint64_t m_pas;
+};
+
+}
+}
+}
+
+#endif

--- a/bfvmm/include/hve/arch/intel_x64/phys_mtrr.h
+++ b/bfvmm/include/hve/arch/intel_x64/phys_mtrr.h
@@ -1,0 +1,197 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2017 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef PHYS_MTRR_INTEL_X64_EAPIS_H
+#define PHYS_MTRR_INTEL_X64_EAPIS_H
+
+#include <arch/intel_x64/mtrr.h>
+#include "../../../hve/arch/intel_x64/mtrr.h"
+#include "../../../hve/arch/intel_x64/base.h"
+
+namespace eapis
+{
+namespace intel_x64
+{
+
+/// MTRRs
+///
+/// MTRRs are typically set by the BIOS. There is also an ACPI/e820 table
+/// that describes the range types (could be useful for emulation).
+///
+/// There are two types of ranges that MTRRs specify: fixed and variable.
+/// The first 1MB of physical memory is specified by the 11 fixed-range MTRRs
+/// (i.e. 11 MSRs), with each MTRR divided into eight, 1-byte sub-ranges:
+///
+/// [0x00000, 0x7FFFF] (1 MSR * 8 sub-ranges * 64KB each == 512KB)
+/// [0x80000, 0xBFFFF] (2 MSR * 8 sub-ranges * 16KB each == 256KB)
+/// [0xC0000, 0xFFFFF] (8 MSR * 8 sub-ranges * 4KB  each == 256KB)
+///
+/// The number of variable ranges is IA32_MTRRCAP[7:0], and each range
+/// is specified with two MSRs; one that describes the base and memory type,
+/// and another that helps determine the range size.
+
+/// Physical MTRR interface
+///
+/// This class provides a light-weight abstration over the platforms
+/// memory type range registers (MTRRs).
+///
+class EXPORT_EAPIS_HVE phys_mtrr
+{
+public:
+
+    /// There are 88 fixed ranges total
+    static constexpr uint64_t s_fixed_count = 88U;
+
+    /// The total size over all fixed range MTRRs is 1MB. The base is
+    /// defined by the manual as 0.
+    static constexpr uint64_t s_fixed_size = 0x100000U; // First 1MB
+
+    /// Default Constructor
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    phys_mtrr();
+
+    /// Destructor
+    ///
+    /// @expects
+    /// @ensures
+    ///
+    ~phys_mtrr() = default;
+
+    /// Default type
+    ///
+    /// @return the default memory type.
+    ///
+    uint64_t default_mem_type() const;
+
+    /// Memory type
+    ///
+    /// @param addr the address to lookup
+    /// @return the memory type for the given address.
+    ///
+    uint64_t mem_type(uintptr_t addr) const;
+
+    /// Range list
+    ///
+    /// Return a set of ranges, each with one memory type, ordered
+    /// by ascending address starting from the given @param base and
+    /// extending to @param base + @param size - 1.
+    ///
+    /// @note each produced range is a multple of 4KB > 0
+    /// @note the guarantee of one type per range does not imply that the range
+    /// only has one type as programmed by the physical MTRRs. It is possible that
+    /// there are several types mapped over the range. In this case, the smallest
+    /// range with multiple types will be computed, and the type returned for that
+    /// range will be the same as described by the precedence rules in
+    /// section 11.11.4.1. This overlap seems unlikely in practice.
+    ///
+    /// @param[in] base the base of the range
+    /// @param[in] size the number of bytes in the range
+    /// @param[in,out] list the list of ranges
+    ///
+    void range_list(
+        const uintptr_t base,
+        const uint64_t size,
+        std::vector<mtrr::range> &list) const;
+
+    /// Enabled
+    ///
+    /// @return true iff the 'e' bit in IA32_MTRR_DEF_TYPE is 1
+    /// @return true does not imply that the fixed range MTRRs are enabled
+    ///
+    bool enabled() const;
+
+    /// Variable count
+    ///
+    /// @return the number of variable ranges
+    ///
+    uint64_t variable_count() const;
+
+    /// Fixed count
+    ///
+    /// @return the number of fixed ranges
+    ///
+    uint64_t fixed_count() const;
+
+    /// Variable supported
+    ///
+    /// @return true iff at least one variable MTRR is supported
+    ///
+    bool variable_supported() const;
+
+    /// Fixed supported
+    ///
+    /// @return true iff fixed range MTRRs (IA32_MTRR_FIX64k_00000 through
+    /// IA32_MTRR_FIX4K_0F8000) are supported
+    ///
+    bool fixed_supported() const;
+
+    /// Fixed enabled
+    ///
+    /// @return true iff fixed-range MTRRs are enabled
+    ///
+    bool fixed_enabled() const;
+
+    /// WC supported
+    ///
+    /// @return true iff the write-combining memory type is supported
+    ///
+    bool wc_supported() const;
+
+    /// SMRR supported
+    ///
+    /// @return true iff the system-management range register (SMRR) interface
+    /// is supported
+    ///
+    bool smrr_supported() const;
+
+private:
+
+    void init_variable_ranges();
+    void init_fixed_ranges();
+    void init_fixed_types();
+    void print_fixed_ranges(uint64_t level) const;
+    void print_variable_ranges(uint64_t level) const;
+
+    std::array<uint64_t, 256U> m_fixed_range = {0U};
+    std::array<uint64_t, s_fixed_count> m_fixed_type = {0U};
+    std::vector<eapis::intel_x64::mtrr::variable_range> m_variable_range;
+
+    uint64_t m_pas; // Physical address size
+    uint64_t m_cap; // MTRR capability MSR
+    uint64_t m_def; // MTRR default type MSR
+
+public:
+
+    // @cond
+
+    phys_mtrr(phys_mtrr &&) = default;
+    phys_mtrr &operator=(phys_mtrr &&) = default;
+
+    phys_mtrr(const phys_mtrr &) = delete;
+    phys_mtrr &operator=(const phys_mtrr &) = delete;
+
+    /// @endcond
+};
+
+}
+}
+
+#endif

--- a/bfvmm/include/support/arch/intel_x64/test_support.h
+++ b/bfvmm/include/support/arch/intel_x64/test_support.h
@@ -52,6 +52,29 @@ std::unique_ptr<eapis::intel_x64::ept::memory_map> g_emap;
 
 struct platform_info_t g_platform_info;
 
+extern "C" uint64_t
+_bsf(uint64_t value) noexcept
+{
+    for (size_t i = 0U; i < 64U; ++i) {
+        if (((1ULL << i) & value) != 0U) {
+            return i;
+        }
+    }
+    return ~0ULL;
+}
+
+extern "C" uint64_t
+_popcnt(uint64_t value) noexcept
+{
+    size_t count = 0U;
+    for (size_t i = 0U; i < 64U; ++i) {
+        if (((1ULL << i) & value) != 0U) {
+            ++count;
+        }
+    }
+    return count;
+}
+
 extern "C" struct platform_info_t *
 get_platform_info(void)
 { return &g_platform_info; }

--- a/bfvmm/src/hve/CMakeLists.txt
+++ b/bfvmm/src/hve/CMakeLists.txt
@@ -29,6 +29,7 @@ if(${BUILD_TARGET_ARCH} STREQUAL "x86_64")
         arch/intel_x64/esr.cpp
         arch/intel_x64/isr.cpp
         arch/intel_x64/phys_ioapic.cpp
+        arch/intel_x64/phys_mtrr.cpp
         arch/intel_x64/phys_xapic.cpp
         arch/intel_x64/phys_x2apic.cpp
         arch/intel_x64/virt_ioapic.cpp

--- a/bfvmm/src/hve/arch/intel_x64/phys_mtrr.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/phys_mtrr.cpp
@@ -1,0 +1,328 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <array>
+#include <cstdio>
+#include <arch/x64/misc.h>
+#include <arch/intel_x64/bit.h>
+#include <arch/intel_x64/mtrr.h>
+#include <hve/arch/intel_x64/mtrr.h>
+#include <hve/arch/intel_x64/phys_mtrr.h>
+#include <hve/arch/intel_x64/ept/helpers.h>
+
+namespace eapis
+{
+namespace intel_x64
+{
+
+using namespace ::intel_x64::mtrr;
+
+///
+/// Helpers
+///
+static inline uint64_t fixed_range_size(uint64_t range)
+{
+    expects(range <= 87U);
+
+    if (range <= 7U) {
+        return 1U << 16U;
+    }
+    else if (range <= 23U) {
+        return 1U << 14U;
+    }
+
+    return 1U << 12U;
+}
+
+static inline bool in_fixed_range(uintptr_t addr)
+{ return addr < phys_mtrr::s_fixed_size; }
+
+void
+phys_mtrr::print_variable_ranges(uint64_t level) const
+{
+    for (auto i = 0U; i < m_variable_range.size(); ++i) {
+        bfdebug_text(level, "type", type_to_cstr(m_variable_range[i].type()));
+        bfdebug_subnhex(level, "base", m_variable_range[i].base());
+        bfdebug_subnhex(level, "mask", m_variable_range[i].mask());
+        bfdebug_subnhex(level, "size", m_variable_range[i].size());
+    }
+}
+
+void
+phys_mtrr::print_fixed_ranges(uint64_t level) const
+{
+    uint64_t size = 0U;
+    uint64_t base = 0U;
+    uint64_t type = m_fixed_type[0];
+
+    for (auto i = 0U; i < m_fixed_type.size(); ++i) {
+        if (type == m_fixed_type.at(i)) {
+            size += fixed_range_size(i);
+            continue;
+        }
+
+        bfdebug_text(level, "type", type_to_cstr(m_fixed_type[i - 1U]));
+        bfdebug_subnhex(level, "base", base);
+        bfdebug_subnhex(level, "last", base + (size - 1U));
+
+        base += size;
+        type = m_fixed_type.at(i);
+        size = fixed_range_size(i);
+    }
+
+    if (type == m_fixed_type[m_fixed_type.size() - 1U]) {
+        bfdebug_text(level, "type", type_to_cstr(type));
+        bfdebug_subnhex(level, "base", base);
+        bfdebug_subnhex(level, "last", base + (size - 1U));
+    }
+}
+
+///
+/// Implementation
+///
+phys_mtrr::phys_mtrr()
+{
+    expects(::intel_x64::mtrr::is_supported());
+
+    const auto cap = ia32_mtrrcap::get();
+    const auto num = ia32_mtrrcap::vcnt::get(cap);
+    expects(num > 0U && num <= 0xFFU);
+
+    const auto def = ia32_mtrr_def_type::get();
+    expects(ia32_mtrr_def_type::e::is_enabled(def));
+
+    m_cap = cap;
+    m_def = def;
+    m_pas = ::x64::cpuid::addr_size::phys::get();
+
+    this->init_fixed_ranges();
+    this->init_variable_ranges();
+
+    bfdebug_transaction(1, [&](std::string *) {
+        this->print_fixed_ranges(1);
+        this->print_variable_ranges(1);
+    });
+}
+
+/// Init fixed ranges
+///
+/// This functions creates a mapping from {0..255} to {0..87}. Each
+/// mapped value is an index into a memory type table. Each conditional
+/// corresponds to the set of ranges with the same granularity i.e. 64KB,
+/// 16KB, and 4KB. Each value assigned to 'at(i)' is the index that byte
+/// i maps to in the type array. Table 11-9 in the Intel SDM contains 88 entries,
+/// and each entry can have a different memory type. Note the map
+/// {0..87} -> {memory types} is provided in the fixed_type array.
+///
+/// As a plus, once -std=c++17 is fully integrated, this function can be
+/// made constexpr.
+///
+void
+phys_mtrr::init_fixed_ranges()
+{
+    for (auto i = 0U; i <= 0xFFU; ++i) {
+        if (i <= 0x7FU) {
+            m_fixed_range.at(i) = (i & 0x70U) >> 4U;
+        }
+        else if (i <= 0xBFU) {
+            const uint64_t mod = 4U;
+            const uint64_t base = 8U;
+            const uint64_t scale = ((i & 0xF0U) >> 4U) & (mod - 1U);
+            const uint64_t index = ((i & 0x0FU) >> 2U);
+            m_fixed_range.at(i) = gsl::narrow_cast<uint64_t>(
+                                      base + index + (scale * mod));
+        }
+        else if (i <= 0xFF) {
+            const uint64_t mod = 16U;
+            const uint64_t base = 24U;
+            const uint64_t scale = (((i & 0xF0U) >> 4U) & (mod - 1U)) - 0xCU;
+            const uint64_t index = i & 0x0FU;
+            m_fixed_range.at(i) = gsl::narrow_cast<uint64_t>(
+                                      base + index + (scale * mod));
+        }
+    }
+
+    this->init_fixed_types();
+}
+
+void
+phys_mtrr::init_variable_ranges()
+{
+    const auto vcnt = ia32_mtrrcap::vcnt::get(m_cap);
+    const auto base_addr = ia32_physbase::start_addr;
+    const auto mask_addr = ia32_physmask::start_addr;
+
+    for (auto i = 0U; i < (vcnt << 1U); i += 2U) {
+        const auto mask_msr = ::intel_x64::msrs::get(mask_addr + i);
+        if (ia32_physmask::valid::is_disabled(mask_msr)) {
+            continue;
+        }
+        const auto base_msr = ::intel_x64::msrs::get(base_addr + i);
+        m_variable_range.push_back({base_msr, mask_msr, m_pas});
+    }
+}
+
+void
+phys_mtrr::init_fixed_types()
+{
+    const std::array<::intel_x64::msrs::field_type, 11U> addrs = {{
+            fix64k_00000::addr,
+            fix16k_80000::addr,
+            fix16k_A0000::addr,
+            fix4k_C0000::addr,
+            fix4k_C8000::addr,
+            fix4k_D0000::addr,
+            fix4k_D8000::addr,
+            fix4k_E0000::addr,
+            fix4k_E8000::addr,
+            fix4k_F0000::addr,
+            fix4k_F8000::addr
+        }
+    };
+
+    for (uint64_t i = 0U; i < addrs.size(); ++i) {
+        const auto msr = ::intel_x64::msrs::get(addrs.at(i));
+        constexpr auto size = 8ULL;
+
+        for (uint64_t j = 0U; j < size; ++j) {
+            const auto from = (j << 3U);
+            const auto mask = 0xFFULL << from;
+            m_fixed_type.at((i << 3U) + j) = get_bits(msr, mask) >> from;
+        }
+    }
+}
+
+uint64_t
+phys_mtrr::variable_count() const
+{ return ia32_mtrrcap::vcnt::get(); }
+
+uint64_t
+phys_mtrr::fixed_count() const
+{ return 11U; }
+
+bool
+phys_mtrr::variable_supported() const
+{ return this->variable_count() > 0U; }
+
+bool
+phys_mtrr::fixed_supported() const
+{ return ia32_mtrrcap::fixed_support::is_enabled(m_cap); }
+
+bool
+phys_mtrr::wc_supported() const
+{ return ia32_mtrrcap::wc_support::is_enabled(m_cap); }
+
+bool
+phys_mtrr::smrr_supported() const
+{ return ia32_mtrrcap::smrr_support::is_enabled(m_cap); }
+
+uint64_t
+phys_mtrr::default_mem_type() const
+{ return ia32_mtrr_def_type::type::get(m_def); }
+
+bool
+phys_mtrr::fixed_enabled() const
+{
+    return ia32_mtrr_def_type::e::is_enabled(m_def) &&
+           ia32_mtrr_def_type::fe::is_enabled(m_def);
+}
+
+bool
+phys_mtrr::enabled() const
+{ return ia32_mtrr_def_type::e::is_enabled(m_def); }
+
+uint64_t
+phys_mtrr::mem_type(uintptr_t addr) const
+{
+    if (in_fixed_range(addr)) {
+        if (GSL_LIKELY(ia32_mtrr_def_type::fe::is_enabled(m_def))) {
+            const auto range = get_bits(addr, 0xFF000ULL) >> 12U;
+            return m_fixed_type.at(m_fixed_range.at(range));
+        }
+    }
+
+    uint64_t type_bitmap = 0U;
+    for (auto i = 0U; i < m_variable_range.size(); ++i) {
+        if (m_variable_range.at(i).contains(addr)) {
+            type_bitmap |= (1U << m_variable_range.at(i).type());
+        }
+    }
+
+    switch (::intel_x64::bit::popcnt(type_bitmap)) {
+        case 0U:
+            return ia32_mtrr_def_type::type::get(m_def);
+        case 1U:
+            return ::intel_x64::bit::bsf(type_bitmap);
+        default:
+            if ((type_bitmap & uncacheable_mask) != 0U) {
+                return uncacheable;
+            }
+            else if (type_bitmap == (write_through_mask | write_back_mask)) {
+                return write_through;
+            }
+
+            bferror_info(0, "Undefined MTRR overlap");
+            bferror_nhex(0, "addr", addr);
+            bferror_nhex(0, "type_bitmap", type_bitmap);
+            throw std::runtime_error("Undefined MTRR overlap at addr " +
+                                     std::to_string(addr));
+    }
+}
+
+void
+phys_mtrr::range_list(
+    const uintptr_t base,
+    const uint64_t size,
+    std::vector<mtrr::range> &list) const
+{
+    expects(size > 0U);
+    expects(size == ept::align_4k(size));
+    expects(base == ept::align_4k(base));
+    expects(base < (base + size));
+
+    uint64_t pages = 0U;
+    uint64_t type = this->mem_type(base);
+    uint64_t prev_type = type;
+    uintptr_t prev_base = base;
+    constexpr const uint64_t page_size = 0x1000U;
+
+    this->print_variable_ranges(0);
+
+    for (uint64_t addr = base; addr < (base + size); addr += page_size) {
+        type = this->mem_type(addr);
+        if (type == prev_type) {
+            ++pages;
+            continue;
+        }
+
+        list.push_back({prev_base, pages * page_size, prev_type});
+
+        prev_base = addr;
+        prev_type = type;
+        pages = 1U;
+    }
+
+    if (type != prev_type) {
+        return;
+    }
+
+    list.push_back({prev_base, pages * page_size, prev_type});
+}
+
+}
+}

--- a/bfvmm/tests/hve/CMakeLists.txt
+++ b/bfvmm/tests/hve/CMakeLists.txt
@@ -43,6 +43,7 @@ do_test(test_memory_map
 do_test(test_ept_helpers
     SOURCES arch/intel_x64/ept/test_helpers.cpp
     SOURCES arch/intel_x64/ept/ept_test_support.cpp
+    CMD_LINE_ARGS ASAN_OPTIONS=detect_leaks=0
     ${ARGN}
 )
 
@@ -53,6 +54,11 @@ do_test(test_vpid
 
 do_test(test_phys_ioapic
     SOURCES arch/intel_x64/test_phys_ioapic.cpp
+    ${ARGN}
+)
+
+do_test(test_phys_mtrr
+    SOURCES arch/intel_x64/test_phys_mtrr.cpp
     ${ARGN}
 )
 

--- a/bfvmm/tests/hve/arch/intel_x64/test_phys_mtrr.cpp
+++ b/bfvmm/tests/hve/arch/intel_x64/test_phys_mtrr.cpp
@@ -1,0 +1,398 @@
+//
+// Bareflank Extended APIs
+//
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <array>
+
+#include <arch/x64/misc.h>
+#include <arch/intel_x64/cpuid.h>
+#include <hve/arch/intel_x64/mtrr.h>
+#include <hve/arch/intel_x64/phys_mtrr.h>
+#include <support/arch/intel_x64/test_support.h>
+
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
+namespace eapis
+{
+namespace intel_x64
+{
+
+using namespace ::x64::cpuid;
+using namespace ::intel_x64::cpuid;
+using namespace ::intel_x64::mtrr;
+using namespace eapis::intel_x64::mtrr;
+
+static const std::array<uint64_t, 5U> mtrr_type = {{
+        uncacheable,
+        write_combining,
+        write_through,
+        write_protected,
+        write_back
+    }
+};
+
+static const std::array<::intel_x64::msrs::field_type, 11U> fixed_addrs = {{
+        fix64k_00000::addr,
+        fix16k_80000::addr,
+        fix16k_A0000::addr,
+        fix4k_C0000::addr,
+        fix4k_C8000::addr,
+        fix4k_D0000::addr,
+        fix4k_D8000::addr,
+        fix4k_E0000::addr,
+        fix4k_E8000::addr,
+        fix4k_F0000::addr,
+        fix4k_F8000::addr
+    }
+};
+
+void enable_mtrr()
+{
+    g_edx_cpuid[feature_information::addr] |=
+        feature_information::edx::mtrr::mask;  // expose through cpuid
+    g_eax_cpuid[addr_size::addr] = 39U;        // phys addr size
+
+    ia32_mtrr_def_type::e::enable();           // enable MTRRs
+    ia32_mtrr_def_type::fe::enable();          // enable fixed ranges
+
+    g_msrs[ia32_mtrrcap::addr] = (1U << 11U);  // enable smrr support
+    g_msrs[ia32_mtrrcap::addr] |= (1U << 10U); // enable wc support
+    g_msrs[ia32_mtrrcap::addr] |= (1U << 8U);  // enable fixed support
+    g_msrs[ia32_mtrrcap::addr] |= 1U;          // set vcnt to 1
+}
+
+static uint64_t init_multi_fixed()
+{
+    expects(mtrr_type.size() == 5U);
+
+    uint64_t val = 0U;
+    for (auto j = 0U; j < mtrr_type.size(); ++j) {
+        val |= mtrr_type.at(j) << (j << 3U);
+    }
+
+    return val;
+}
+
+static bool
+check_fixed_ranges(phys_mtrr &&mtrr, uint64_t *base, size_t regs, size_t size)
+{
+    for (uint64_t b = 0U; b < regs; ++b) {
+        for (auto i = 0U; i < 8U; ++i) {
+            auto addr = base[b] + (i * size);
+            if (i < 5U) {
+                if (mtrr.mem_type(addr) != mtrr_type.at(i)) {
+                    return false;
+                }
+                continue;
+            }
+
+            if (mtrr.mem_type(addr) != uncacheable) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+static bool check_64kb_ranges(phys_mtrr &&mtrr)
+{
+    constexpr auto regs = 1U;
+    constexpr auto size = (1U << 16U);
+    std::array<uint64_t, regs> base = {0x00000U};
+
+    return check_fixed_ranges(std::move(mtrr), base.data(), regs, size);
+}
+
+static bool check_16kb_ranges(phys_mtrr &&mtrr)
+{
+    constexpr auto regs = 2U;
+    constexpr auto size = (1U << 14U);
+    std::array<uint64_t, regs> base = {0x80000U, 0xA0000U};
+
+    return check_fixed_ranges(std::move(mtrr), base.data(), regs, size);
+}
+
+static bool check_4kb_ranges(phys_mtrr &&mtrr)
+{
+    constexpr auto regs = 8U;
+    constexpr auto size = (1U << 12U);
+    std::array<uint64_t, regs> base = {
+        0xC0000U, 0xC8000U, 0xD0000U, 0xD8000U,
+        0xE0000U, 0xE8000U, 0xF0000U, 0xF8000U
+    };
+
+    return check_fixed_ranges(std::move(mtrr), base.data(), regs, size);
+}
+
+TEST_CASE("phys_mtrr: constructor")
+{
+    g_edx_cpuid[feature_information::addr] = 0U;
+    CHECK_THROWS(phys_mtrr());
+
+    g_edx_cpuid[feature_information::addr] = ~0U;
+    ia32_mtrr_def_type::e::disable();
+    CHECK_THROWS(phys_mtrr());
+
+    ia32_mtrr_def_type::e::enable();
+    g_eax_cpuid[addr_size::addr] = 0U;
+    CHECK_THROWS(phys_mtrr());
+
+    g_eax_cpuid[addr_size::addr] = 39U;
+    uint64_t base = 0xFFFFFFFFFFFFFFFFU;
+    ::intel_x64::msrs::set(ia32_physbase::start_addr, base);
+    CHECK_THROWS(phys_mtrr());
+
+    uint64_t mask = 0xFFFFFFFFFFFFFFFFU;
+    base = 0x10000U;
+    ::intel_x64::msrs::set(ia32_physbase::start_addr, base);
+    ::intel_x64::msrs::set(ia32_physmask::start_addr, mask);
+    CHECK_THROWS(phys_mtrr());
+
+    base |= 0xFFU;
+    ::intel_x64::msrs::set(ia32_physbase::start_addr, base);
+    CHECK_THROWS(phys_mtrr());
+
+    base = 0x080000U;
+    mask = size_to_mask(0x1000U, 39U) | (1U << 11U);
+    ::intel_x64::msrs::set(ia32_physbase::start_addr, base);
+    ::intel_x64::msrs::set(ia32_physmask::start_addr, mask);
+
+    g_msrs[ia32_mtrrcap::addr] = 1U;
+    ia32_mtrr_def_type::type::set(write_back);
+    CHECK_NOTHROW(phys_mtrr());
+}
+
+TEST_CASE("phys_mtrr: ia32_mtrrcap fields")
+{
+    enable_mtrr();
+    auto mtrr = phys_mtrr();
+
+    CHECK(mtrr.variable_count() == 1U);
+    CHECK(mtrr.fixed_count() == 11U);
+    CHECK(mtrr.enabled());
+    CHECK(mtrr.fixed_enabled());
+    CHECK(mtrr.wc_supported());
+    CHECK(mtrr.fixed_supported());
+    CHECK(mtrr.smrr_supported());
+}
+
+TEST_CASE("phys_mtrr: mem_type - fixed, single type")
+{
+    enable_mtrr();
+
+    for (const uint64_t type : mtrr_type) {
+        for (auto i = 0U; i < 11U; ++i) {
+            uint64_t val = 0U;
+
+            /// Assign the same type to all ranges
+            for (uint64_t j = 0U; j < 8U; ++j) {
+                val |= type << (j << 3U);
+            }
+            ::intel_x64::msrs::set(fixed_addrs.at(i), val);
+        }
+
+        auto mtrr = phys_mtrr();
+        CHECK(mtrr.fixed_enabled());
+
+        for (auto i = 0U; i < phys_mtrr::s_fixed_size; i += 0x1000U) {
+            CHECK(mtrr.mem_type(i) == type);
+        }
+    }
+}
+
+TEST_CASE("phys_mtrr: mem_type - fixed, 64KB, multi-type")
+{
+    enable_mtrr();
+    auto val = init_multi_fixed();
+
+    ::intel_x64::msrs::set(fix64k_00000::addr, val);
+
+    auto mtrr = phys_mtrr();
+    CHECK(mtrr.fixed_enabled());
+    CHECK(check_64kb_ranges(std::move(mtrr)));
+}
+
+TEST_CASE("phys_mtrr: mem_type - fixed, 16KB, multi-type")
+{
+    enable_mtrr();
+    auto val = init_multi_fixed();
+
+    ::intel_x64::msrs::set(fix16k_80000::addr, val);
+    ::intel_x64::msrs::set(fix16k_A0000::addr, val);
+
+    auto mtrr = phys_mtrr();
+    CHECK(mtrr.fixed_enabled());
+    CHECK(check_16kb_ranges(std::move(mtrr)));
+}
+
+TEST_CASE("phys_mtrr: mem_type - fixed, 4KB, multi-type")
+{
+    enable_mtrr();
+    auto val = init_multi_fixed();
+
+    ::intel_x64::msrs::set(fix4k_C0000::addr, val);
+    ::intel_x64::msrs::set(fix4k_C8000::addr, val);
+    ::intel_x64::msrs::set(fix4k_D0000::addr, val);
+    ::intel_x64::msrs::set(fix4k_D8000::addr, val);
+    ::intel_x64::msrs::set(fix4k_E0000::addr, val);
+    ::intel_x64::msrs::set(fix4k_E8000::addr, val);
+    ::intel_x64::msrs::set(fix4k_F0000::addr, val);
+    ::intel_x64::msrs::set(fix4k_F8000::addr, val);
+
+    auto mtrr = phys_mtrr();
+    CHECK(mtrr.fixed_enabled());
+    CHECK(check_4kb_ranges(std::move(mtrr)));
+}
+
+TEST_CASE("phys_mtrr: mem_type - variable")
+{
+    enable_mtrr();
+
+    uint64_t physbase = 0U;
+    uint64_t physmask = 0U;
+    uint64_t pas = g_eax_cpuid[addr_size::addr];
+    uint64_t mask = size_to_mask(0x2000U, pas);
+
+    ia32_physbase::physbase::set(physbase, 0x800000U, pas);
+    ia32_physmask::physmask::set(physmask, mask, pas);
+    ia32_physmask::valid::enable(physmask);
+
+    msrs_n::set(ia32_physmask::start_addr, physmask);
+    std::array<uint64_t, 3U> invalid_mtrr_type = {2U, 3U, 7U};
+
+    for (auto type : invalid_mtrr_type) {
+        ia32_physbase::type::set(physbase, type);
+        msrs_n::set(ia32_physbase::start_addr, physbase);
+        CHECK_THROWS(phys_mtrr());
+    }
+
+    for (auto type : mtrr_type) {
+        ia32_physbase::type::set(physbase, type);
+        msrs_n::set(ia32_physbase::start_addr, physbase);
+
+        auto mtrr = phys_mtrr();
+        CHECK(mtrr.mem_type(0x800000000U) == type);
+    }
+}
+
+TEST_CASE("phys_mtrr: range_list throws")
+{
+    enable_mtrr();
+    std::vector<mtrr::range> list;
+    auto mtrr = phys_mtrr();
+
+    CHECK_THROWS(mtrr.range_list(0, 0x0000, list));
+    CHECK_THROWS(mtrr.range_list(1, 0x1000, list));
+    CHECK_THROWS(mtrr.range_list(0, 0x1002, list));
+    CHECK_THROWS(mtrr.range_list(~0ULL, 0x1000, list));
+}
+
+TEST_CASE("phys_mtrr: range_list over fixed")
+{
+    enable_mtrr();
+    std::vector<mtrr::range> list;
+    auto val = init_multi_fixed();
+
+    ::intel_x64::msrs::set(fix64k_00000::addr, val);
+
+    auto mtrr = phys_mtrr();
+    mtrr.range_list(0, 8 * (1U << 16U), list);
+    CHECK(list.size() == 6U);
+
+    for (auto i = 0U; i < 5U; ++i) {
+        CHECK(list[i].base == i * (1U << 16U));
+        CHECK(list[i].size == (1U << 16U));
+    }
+
+    CHECK(list[5].base == 5 * (1U << 16U));
+    CHECK(list[5].size == 3 * (1U << 16U));
+
+    CHECK(list[0].type == uncacheable);
+    CHECK(list[1].type == write_combining);
+    CHECK(list[2].type == write_through);
+    CHECK(list[3].type == write_protected);
+    CHECK(list[4].type == write_back);
+    CHECK(list[5].type == uncacheable);
+}
+
+TEST_CASE("phys_mtrr: range_list over variable")
+{
+    enable_mtrr();
+
+    std::array<uint64_t, 3U> type = {
+        uncacheable, write_protected, write_through
+    };
+    std::array<uint64_t, 3U> size = {
+        0x1000U, 0x4000U, 0x40000000U
+    };
+    std::array<uintptr_t, 3U> base = {
+        0x100000U, 0x204000U, 0x40000000U
+    };
+    expects(base.size() == size.size() && size.size() == type.size());
+
+    for (auto i = 0U; i < base.size(); ++i) {
+        uint64_t physbase = 0U;
+        uint64_t physmask = 0U;
+        uint64_t pas = g_eax_cpuid[addr_size::addr];
+        uint64_t mask = size_to_mask(size[i], pas);
+
+        ia32_physbase::type::set(physbase, type[i]);
+        ia32_physbase::physbase::set(physbase, base[i] >> 12U, pas);
+
+        ia32_physmask::valid::enable(physmask);
+        ia32_physmask::physmask::set(physmask, mask >> 12U, pas);
+
+        msrs_n::set(ia32_physbase::start_addr + (i * 2U), physbase);
+        msrs_n::set(ia32_physmask::start_addr + (i * 2U), physmask);
+    }
+
+    uint64_t cap = ia32_mtrrcap::get();
+    g_msrs[ia32_mtrrcap::addr] = (cap & ~0xFFULL) | base.size();
+    ia32_mtrr_def_type::type::set(write_back);
+
+    auto mtrr = phys_mtrr();
+    std::vector<mtrr::range> list{0};
+    mtrr.range_list(base[0], (base[2] + size[2]) - base[0], list);
+
+    CHECK(list.size() == 5U); // 3 explicit ranges + 2 holes
+    CHECK(list[0].base == base[0]);
+    CHECK(list[0].size == size[0]);
+    CHECK(list[0].type == type[0]);
+
+    CHECK(list[1].base == list[0].base + list[0].size);
+    CHECK(list[1].size == base[1] - list[1].base);
+    CHECK(list[1].type == write_back);
+
+    CHECK(list[2].base == base[1]);
+    CHECK(list[2].size == size[1]);
+    CHECK(list[2].type == type[1]);
+
+    CHECK(list[3].base == list[2].base + list[2].size);
+    CHECK(list[3].size == base[2] - list[3].base);
+    CHECK(list[3].type == write_back);
+
+    CHECK(list[4].base == base[2]);
+    CHECK(list[4].size == size[2]);
+    CHECK(list[4].type == type[2]);
+}
+
+}
+}
+
+#endif


### PR DESCRIPTION
- Add a minimal mtrr::variable_range class along with static helpers
  for parsing the fields out of the class's physbase and physmask
  msr members.

- Provide an interface that clients may use to query the memory type
  of a physical address as specified by the MTRRs. The
  phys_mtrr::mem_type function takes a host-physical address and returns
  one of the types listed in bfintrinsics/include/arch/intel_x64/mtrr.h

- Add phys_mtrr unit tests

Signed-off-by: Connor Davis <davisc@ainfosec.com>