### PR TITLE
EAPIs Unit Test Bug

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,21 @@
+#
+# Bareflank Hypervisor
+# Copyright (C) 2015 Assured Information Security, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
 os: Visual Studio 2017
 platform: x64
 
@@ -9,11 +27,12 @@ environment:
     CYG_ROOT: C:\cygwin_bareflank
     CYG_BASH: C:\cygwin_bareflank\bin\bash
     CYG_MIRROR: http://mirrors.kernel.org/sourceware/cygwin/
-    CYG_PACKAGES: git,make,gcc-core,gcc-g++,nasm,clang,clang++,cmake,python,gettext
+    CYG_PACKAGES: make,gcc-core,gcc-g++,nasm,clang,clang++,cmake,python,gettext
     BFPATH: '%PATH%'
     PATH: '%PATH%;C:\Program Files\NASM'
 
-test: off
+cache:
+  - ../cache
 
 #
 # Setup Cygwin
@@ -38,20 +57,27 @@ install:
 build_script:
 
   #
-  # Visual Studio (MSBuild / Static Libraries)
+  # Depends
   #
   - git clone https://github.com/bareflank/hypervisor.git hypervisor
-  - mkdir hypervisor\build
-  - cd hypervisor\build
-  - cmake -G "Visual Studio 15 2017 Win64" -DEXTENSION=..\.. -DENABLE_BUILD_VMM=OFF -DENABLE_BUILD_USERSPACE=OFF -DENABLE_BUILD_TEST=ON ..
+
+  #
+  # Visual Studio (MSBuild / Static Libraries)
+  #
+  - mkdir build_msbuild
+  - cd build_msbuild
+  - cmake -G "Visual Studio 15 2017 Win64" -DEXTENSION=.. -DENABLE_BUILD_VMM=OFF -DENABLE_BUILD_USERSPACE=OFF -DENABLE_BUILD_TEST=ON ../hypervisor
   - msbuild /m:3 hypervisor.sln
-  - cmake --build . --target eapis_x86_64-test-pe
-  - cd ..
+  - cmake --build . --target unittest
 
   #
   # Cygwin (Shared Libraries)
   #
-  - set PATH=%BFPATH%;%APPVEYOR_BUILD_FOLDER%/hypervisor/build_cygwin/bfprefix/bin
-  - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; ls; mkdir hypervisor/build_cygwin"'
-  - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER/hypervisor/build_cygwin; cmake -DEXTENSION=../..  .."'
-  - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER/hypervisor/build_cygwin; make -j3"'
+  - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; mkdir build_cygwin"'
+  - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER/build_cygwin; cmake -DEXTENSION=.. ../hypervisor"'
+  - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER/build_cygwin; make -j3"'
+
+#
+# No AppVeyor Tests
+#
+test: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,22 @@
 #
+# Bareflank Hypervisor
+# Copyright (C) 2015 Assured Information Security, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#
 # Configuration
 #
 language: cpp
@@ -17,39 +35,40 @@ cache:
 before_script:
 
   #
-  # Cache
+  # Cache / Depends
   #
   - mkdir -p ../cache
 
   #
-  # Build Folder
+  # Build Enviornment
   #
   - git clone https://github.com/bareflank/hypervisor.git hypervisor
-  - mkdir build
+  - mkdir -p build
   - cd build
-
-  #
-  # Update / Install CMake
-  #
-  - |
-    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      mkdir -p external/cmake
-      pushd external/cmake
-      wget https://cmake.org/files/v3.8/cmake-3.8.0-Linux-x86_64.sh
-      chmod +x cmake-*-Linux-x86_64.sh
-      ./cmake-*-Linux-x86_64.sh --exclude-subdir --skip-license
-      export PATH="${PWD}/bin:$PATH"
-      popd
-    else
-      if ! brew ls --version cmake &>/dev/null; then brew install cmake; fi
-    fi
 
   #
   # Update GCC
   #
-  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 100
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 100
-  - sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-6 100
+  - |
+    if [[ -f "/usr/bin/gcc-6" ]]; then
+      sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 100
+      sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 100
+      sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-6 100
+    fi
+
+  - |
+    if [[ -f "/usr/bin/gcc-7" ]]; then
+      sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 100
+      sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 100
+      sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-7 100
+    fi
+
+  - |
+    if [[ -f "/usr/bin/gcc-8" ]]; then
+      sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 100
+      sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 100
+      sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-8 100
+    fi
 
 #
 # Build Matrix
@@ -66,13 +85,13 @@ matrix:
         sources:
           - ubuntu-toolchain-r-test
         packages:
-          - gcc-6
-          - g++-6
+          - gcc-8
+          - g++-8
           - doxygen
     env:
       - TEST="Doxygen"
     script:
-      - cd ../
+      - cd ..
       - doxygen .doxygen.txt
       - |
         if [[ -s doxygen_warnings.txt ]]; then
@@ -91,8 +110,8 @@ matrix:
         sources:
           - ubuntu-toolchain-r-test
         packages:
-          - gcc-6
-          - g++-6
+          - gcc-8
+          - g++-8
     env:
       - TEST="Git Check"
     script:
@@ -112,18 +131,18 @@ matrix:
       apt:
         sources:
           - ubuntu-toolchain-r-test
-          - llvm-toolchain-trusty-4.0
+          - llvm-toolchain-trusty-6.0
         packages:
-          - gcc-6
-          - g++-6
-          - clang-4.0
+          - gcc-8
+          - g++-8
+          - clang-6.0
           - nasm
     env:
       - TEST="Format"
     script:
-      - cmake -DCONFIG=../hypervisor/scripts/cmake/config/travis_format.cmake -DEXTENSION=.. ../hypervisor
+      - cmake -DCONFIG=travis_format -DEXTENSION=.. ../hypervisor
       - make astyle_x86_64-userspace-elf
-      - make format-all
+      - make format
       - |
         if [[ -n $(git diff) ]]; then
           echo "You must run make format before submitting a pull request"
@@ -135,178 +154,27 @@ matrix:
   #
   # Clang Tidy
   #
-  - os: linux
-    addons:
-      apt:
-        sources:
-          - ubuntu-toolchain-r-test
-          - llvm-toolchain-trusty-4.0
-        packages:
-          - clang-4.0
-          - clang-tidy-4.0
-          - gcc-6
-          - g++-6
-          - nasm
-    env:
-      - TEST="Clang Tidy"
-    script:
-      - cmake -DCONFIG=../hypervisor/scripts/cmake/config/travis_tidy.cmake -DEXTENSION=.. -DENABLE_BUILD_TEST=ON ../hypervisor
-      - make -j3
-      - make tidy
+  # - os: linux
+  #   addons:
+  #     apt:
+  #       sources:
+  #         - ubuntu-toolchain-r-test
+  #         - llvm-toolchain-trusty-6.0
+  #       packages:
+  #         - clang-6.0
+  #         - clang-tidy-6.0
+  #         - gcc-8
+  #         - g++-8
+  #         - nasm
+  #   env:
+  #     - TEST="Clang Tidy"
+  #   script:
+  #     - cmake -DCONFIG=travis_tidy -DEXTENSION=.. ../hypervisor
+  #     - make -j3
+  #     - make tidy
 
   #
   # Codecov
-  #
-  - os: linux
-    addons:
-      apt:
-        sources:
-          - ubuntu-toolchain-r-test
-          - llvm-toolchain-trusty-4.0
-        packages:
-          - gcc-6
-          - g++-6
-          - clang-4.0
-          - nasm
-    env:
-      - TEST="Codecov"
-    script:
-      - export LD_BIN=ld.gold
-      - cmake -DCONFIG=../hypervisor/scripts/cmake/config/travis_codecov.cmake -DEXTENSION=.. -DENABLE_BUILD_TEST=ON ../hypervisor
-      - make -j3 eapis_x86_64-test-elf
-      - make -j3 eapis_bfsdk_x86_64-test-elf
-      - make test
-      - cd ..
-      - bash <(curl -s https://codecov.io/bash)
-
-  #
-  # Google Address Sanitizer
-  #
-  - os: linux
-    addons:
-      apt:
-        sources:
-          - ubuntu-toolchain-r-test
-          - llvm-toolchain-trusty-4.0
-        packages:
-          - gcc-6
-          - g++-6
-          - clang-4.0
-          - nasm
-    env:
-      - TEST="Google Address Sanitizer"
-    script:
-      - cmake -DCONFIG=../hypervisor/scripts/cmake/config/travis_asan.cmake -DEXTENSION=.. -DENABLE_BUILD_TEST=ON ../hypervisor
-      - make -j3
-      - make test
-
-  #
-  # Google Undefined Sanitizer
-  #
-  - os: linux
-    addons:
-      apt:
-        sources:
-          - ubuntu-toolchain-r-test
-          - llvm-toolchain-trusty-4.0
-        packages:
-          - gcc-6
-          - g++-6
-          - clang-4.0
-          - nasm
-    env:
-      - TEST="Google Undefined Sanitizer"
-    script:
-      - cmake -DCONFIG=../hypervisor/scripts/cmake/config/travis_usan.cmake -DEXTENSION=.. -DENABLE_BUILD_TEST=ON ../hypervisor
-      - make -j3
-      - make test
-
-  #
-  # Clang 3.8 (Static Libraries)
-  #
-  - os: linux
-    addons:
-      apt:
-        sources:
-          - ubuntu-toolchain-r-test
-          - llvm-toolchain-trusty-3.8
-        packages:
-          - gcc-6
-          - g++-6
-          - clang-3.8
-          - nasm
-    env:
-      - TEST="Clang 3.8 (Static Libraries)"
-    script:
-      - export CLANG_BIN=clang-3.8
-      - cmake -DCONFIG=../hypervisor/scripts/cmake/config/travis_static.cmake -DEXTENSION=.. ../hypervisor
-      - make -j3
-
-  #
-  # Clang 3.9 (Static Libraries)
-  #
-  - os: linux
-    addons:
-      apt:
-        sources:
-          - ubuntu-toolchain-r-test
-          - llvm-toolchain-trusty-3.9
-        packages:
-          - gcc-6
-          - g++-6
-          - clang-3.9
-          - nasm
-    env:
-      - TEST="Clang 3.9 (Static Libraries)"
-    script:
-      - export CLANG_BIN=clang-3.9
-      - cmake -DCONFIG=../hypervisor/scripts/cmake/config/travis_static.cmake -DEXTENSION=.. ../hypervisor
-      - make -j3
-
-  #
-  # Clang 4.0 (Static Libraries)
-  #
-  - os: linux
-    addons:
-      apt:
-        sources:
-          - ubuntu-toolchain-r-test
-          - llvm-toolchain-trusty-4.0
-        packages:
-          - gcc-6
-          - g++-6
-          - clang-4.0
-          - nasm
-    env:
-      - TEST="Clang 4.0 (Static Libraries)"
-    script:
-      - export CLANG_BIN=clang-4.0
-      - cmake -DCONFIG=../hypervisor/scripts/cmake/config/travis_static.cmake -DEXTENSION=.. ../hypervisor
-      - make -j3
-
-  #
-  # Clang 5.0 (Static Libraries)
-  #
-  - os: linux
-    addons:
-      apt:
-        sources:
-          - ubuntu-toolchain-r-test
-          - llvm-toolchain-trusty-5.0
-        packages:
-          - gcc-6
-          - g++-6
-          - clang-5.0
-          - nasm
-    env:
-      - TEST="Clang 5.0 (Static Libraries)"
-    script:
-      - export CLANG_BIN=clang-5.0
-      - cmake -DCONFIG=../hypervisor/scripts/cmake/config/travis_static.cmake -DEXTENSION=.. ../hypervisor
-      - make -j3
-
-  #
-  # Clang 6.0 (Static Libraries)
   #
   - os: linux
     addons:
@@ -320,71 +188,239 @@ matrix:
           - clang-6.0
           - nasm
     env:
+      - TEST="Codecov"
+    script:
+      - export LD_BIN=ld.gold
+      - cmake -DCONFIG=travis_codecov -DEXTENSION=.. ../hypervisor
+      - make -j3
+      - make unittest
+      - cd ..
+      - bash <(curl -s https://codecov.io/bash)
+
+  #
+  # Google Address Sanitizer
+  #
+  - os: linux
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+          - llvm-toolchain-trusty-6.0
+        packages:
+          - gcc-8
+          - g++-8
+          - clang-6.0
+          - nasm
+    env:
+      - TEST="Google Address Sanitizer"
+    script:
+      - cmake -DCONFIG=travis_asan -DEXTENSION=.. ../hypervisor
+      - make -j3
+      - make unittest
+
+  #
+  # Google Undefined Sanitizer
+  #
+  - os: linux
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+          - llvm-toolchain-trusty-6.0
+        packages:
+          - gcc-8
+          - g++-8
+          - clang-6.0
+          - nasm
+    env:
+      - TEST="Google Undefined Sanitizer"
+    script:
+      - cmake -DCONFIG=travis_usan -DEXTENSION=.. ../hypervisor
+      - make -j3
+      - make unittest
+
+  #
+  # Clang 5.0 (Static Libraries)
+  #
+  - os: linux
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+          - llvm-toolchain-trusty-5.0
+        packages:
+          - gcc-8
+          - g++-8
+          - clang-5.0
+          - nasm
+    env:
+      - TEST="Clang 5.0 (Static Libraries)"
+    script:
+      - export CLANG_BIN=clang-5.0
+      - cmake -DCONFIG=travis_static -DEXTENSION=.. ../hypervisor
+      - make -j3
+
+  #
+  # Clang 6.0 (Static Libraries)
+  #
+  - os: linux
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+          - llvm-toolchain-trusty-6.0
+        packages:
+          - gcc-8
+          - g++-8
+          - clang-6.0
+          - nasm
+    env:
       - TEST="Clang 6.0 (Static Libraries)"
     script:
       - export CLANG_BIN=clang-6.0
-      - cmake -DCONFIG=../hypervisor/scripts/cmake/config/travis_static.cmake -DEXTENSION=.. ../hypervisor
+      - cmake -DCONFIG=travis_static -DEXTENSION=.. ../hypervisor
       - make -j3
 
   #
-  # Clang 3.8 (Shared Libraries)
+  # Clang 5.0 (Shared Libraries)
   #
   - os: linux
     addons:
       apt:
         sources:
           - ubuntu-toolchain-r-test
-          - llvm-toolchain-trusty-3.8
+          - llvm-toolchain-trusty-5.0
         packages:
-          - gcc-6
-          - g++-6
-          - clang-3.8
+          - gcc-8
+          - g++-8
+          - clang-5.0
           - nasm
     env:
-      - TEST="Clang 3.8 (Shared Libraries)"
+      - TEST="Clang 5.0 (Shared Libraries)"
     script:
-      - export CLANG_BIN=clang-3.8
-      - cmake -DCONFIG=../hypervisor/scripts/cmake/config/travis_shared.cmake -DEXTENSION=.. ../hypervisor
+      - export CLANG_BIN=clang-5.0
+      - cmake -DCONFIG=travis_shared -DEXTENSION=.. ../hypervisor
       - make -j3
 
   #
-  # Clang 3.9 (Shared Libraries)
+  # Clang 6.0 (Shared Libraries)
   #
   - os: linux
     addons:
       apt:
         sources:
           - ubuntu-toolchain-r-test
-          - llvm-toolchain-trusty-3.9
+          - llvm-toolchain-trusty-6.0
         packages:
-          - gcc-6
-          - g++-6
-          - clang-3.9
+          - gcc-8
+          - g++-8
+          - clang-6.0
           - nasm
     env:
-      - TEST="Clang 3.9 (Shared Libraries)"
+      - TEST="Clang 6.0 (Shared Libraries)"
     script:
-      - export CLANG_BIN=clang-3.9
-      - cmake -DCONFIG=../hypervisor/scripts/cmake/config/travis_shared.cmake -DEXTENSION=.. ../hypervisor
+      - export CLANG_BIN=clang-6.0
+      - cmake -DCONFIG=travis_shared -DEXTENSION=.. ../hypervisor
       - make -j3
 
   #
-  # Clang 4.0 (Shared Libraries)
+  # GCC 6
   #
   - os: linux
     addons:
       apt:
         sources:
           - ubuntu-toolchain-r-test
-          - llvm-toolchain-trusty-4.0
+          - llvm-toolchain-trusty-6.0
         packages:
           - gcc-6
           - g++-6
-          - clang-4.0
+          - clang-6.0
           - nasm
     env:
-      - TEST="Clang 4.0 (Shared Libraries)"
+      - TEST="GCC 6"
     script:
-      - export CLANG_BIN=clang-4.0
-      - cmake -DCONFIG=../hypervisor/scripts/cmake/config/travis_shared.cmake -DEXTENSION=.. ../hypervisor
+      - cmake -DCONFIG=travis_shared -DEXTENSION=.. ../hypervisor
+      - make -j3
+
+  #
+  # GCC 7
+  #
+  - os: linux
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+          - llvm-toolchain-trusty-6.0
+        packages:
+          - gcc-7
+          - g++-7
+          - clang-6.0
+          - nasm
+    env:
+      - TEST="GCC 7"
+    script:
+      - cmake -DCONFIG=travis_shared -DEXTENSION=.. ../hypervisor
+      - make -j3
+
+  #
+  # GCC 8
+  #
+  - os: linux
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+          - llvm-toolchain-trusty-6.0
+        packages:
+          - gcc-8
+          - g++-8
+          - clang-6.0
+          - nasm
+    env:
+      - TEST="GCC 8"
+    script:
+      - cmake -DCONFIG=travis_shared -DEXTENSION=.. ../hypervisor
+      - make -j3
+
+  #
+  # ld.gold
+  #
+  - os: linux
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+          - llvm-toolchain-trusty-6.0
+        packages:
+          - gcc-8
+          - g++-8
+          - clang-6.0
+          - nasm
+    env:
+      - TEST="ld.gold"
+    script:
+      - export LD_BIN=ld.gold
+      - cmake -DCONFIG=travis_shared -DEXTENSION=.. ../hypervisor
+      - make -j3
+
+  #
+  # ld.lld
+  #
+  - os: linux
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+          - llvm-toolchain-trusty-6.0
+        packages:
+          - gcc-8
+          - g++-8
+          - clang-6.0
+          - nasm
+    env:
+      - TEST="ld.lld"
+    script:
+      - export LD_BIN=ld.lld
+      - cmake -DCONFIG=travis_shared -DEXTENSION=.. ../hypervisor
       - make -j3

--- a/bfsdk/include/bfcapstone.h
+++ b/bfsdk/include/bfcapstone.h
@@ -33,211 +33,211 @@ namespace vmcs_n = ::intel_x64::vmcs;
 
 namespace capstone
 {
-    enum reg_width : uint64_t {
-        byte = 1U,
-        word = 2U,
-        dword = 4U,
-        qword = 8U
-    };
+enum reg_width : uint64_t {
+    byte = 1U,
+    word = 2U,
+    dword = 4U,
+    qword = 8U
+};
 
-    struct reg {
-        enum x86_reg id;
-        enum reg_width width;
-        uint64_t byte_offset;
-    };
+struct reg {
+    enum x86_reg id;
+    enum reg_width width;
+    uint64_t byte_offset;
+};
 
-    constexpr struct reg al = { X86_REG_AL, byte, 0x0U };
-    constexpr struct reg ah = { X86_REG_AH, byte, 0x1U };
-    constexpr struct reg ax = { X86_REG_AX, word, 0x0U };
-    constexpr struct reg eax = { X86_REG_EAX, dword, 0x0U };
-    constexpr struct reg rax = { X86_REG_RAX, qword, 0x0U };
+constexpr struct reg al = { X86_REG_AL, byte, 0x0U };
+constexpr struct reg ah = { X86_REG_AH, byte, 0x1U };
+constexpr struct reg ax = { X86_REG_AX, word, 0x0U };
+constexpr struct reg eax = { X86_REG_EAX, dword, 0x0U };
+constexpr struct reg rax = { X86_REG_RAX, qword, 0x0U };
 
-    constexpr struct reg bl = { X86_REG_BL, byte, 0x8U };
-    constexpr struct reg bh = { X86_REG_BH, byte, 0x9U };
-    constexpr struct reg bx = { X86_REG_BX, word, 0x8U };
-    constexpr struct reg ebx = { X86_REG_EBX, dword, 0x8U };
-    constexpr struct reg rbx = { X86_REG_RBX, qword, 0x8U };
+constexpr struct reg bl = { X86_REG_BL, byte, 0x8U };
+constexpr struct reg bh = { X86_REG_BH, byte, 0x9U };
+constexpr struct reg bx = { X86_REG_BX, word, 0x8U };
+constexpr struct reg ebx = { X86_REG_EBX, dword, 0x8U };
+constexpr struct reg rbx = { X86_REG_RBX, qword, 0x8U };
 
-    constexpr struct reg cl = { X86_REG_CL, byte, 0x10U };
-    constexpr struct reg ch = { X86_REG_CH, byte, 0x11U };
-    constexpr struct reg cx = { X86_REG_CX, word, 0x10U };
-    constexpr struct reg ecx = { X86_REG_ECX, dword, 0x10U };
-    constexpr struct reg rcx = { X86_REG_RCX, qword, 0x10U };
+constexpr struct reg cl = { X86_REG_CL, byte, 0x10U };
+constexpr struct reg ch = { X86_REG_CH, byte, 0x11U };
+constexpr struct reg cx = { X86_REG_CX, word, 0x10U };
+constexpr struct reg ecx = { X86_REG_ECX, dword, 0x10U };
+constexpr struct reg rcx = { X86_REG_RCX, qword, 0x10U };
 
-    constexpr struct reg dl = { X86_REG_DL, byte, 0x18U };
-    constexpr struct reg dh = { X86_REG_DH, byte, 0x19U };
-    constexpr struct reg dx = { X86_REG_DX, word, 0x18U };
-    constexpr struct reg edx = { X86_REG_EDX, dword, 0x18U };
-    constexpr struct reg rdx = { X86_REG_RDX, qword, 0x18U };
+constexpr struct reg dl = { X86_REG_DL, byte, 0x18U };
+constexpr struct reg dh = { X86_REG_DH, byte, 0x19U };
+constexpr struct reg dx = { X86_REG_DX, word, 0x18U };
+constexpr struct reg edx = { X86_REG_EDX, dword, 0x18U };
+constexpr struct reg rdx = { X86_REG_RDX, qword, 0x18U };
 
-    constexpr struct reg bp = { X86_REG_BP, word, 0x20U };
-    constexpr struct reg ebp = { X86_REG_EBP, dword, 0x20U };
-    constexpr struct reg rbp = { X86_REG_RBP, qword, 0x20U };
+constexpr struct reg bp = { X86_REG_BP, word, 0x20U };
+constexpr struct reg ebp = { X86_REG_EBP, dword, 0x20U };
+constexpr struct reg rbp = { X86_REG_RBP, qword, 0x20U };
 
-    constexpr struct reg si = { X86_REG_SI, word, 0x28U };
-    constexpr struct reg esi = { X86_REG_ESI, dword, 0x28U };
-    constexpr struct reg rsi = { X86_REG_RSI, qword, 0x28U };
+constexpr struct reg si = { X86_REG_SI, word, 0x28U };
+constexpr struct reg esi = { X86_REG_ESI, dword, 0x28U };
+constexpr struct reg rsi = { X86_REG_RSI, qword, 0x28U };
 
-    constexpr struct reg di = { X86_REG_DI, word, 0x30U };
-    constexpr struct reg edi = { X86_REG_EDI, dword, 0x30U };
-    constexpr struct reg rdi = { X86_REG_RDI, qword, 0x30U };
+constexpr struct reg di = { X86_REG_DI, word, 0x30U };
+constexpr struct reg edi = { X86_REG_EDI, dword, 0x30U };
+constexpr struct reg rdi = { X86_REG_RDI, qword, 0x30U };
 
-    constexpr struct reg r08 = { X86_REG_R8, qword, 0x38U };
-    constexpr struct reg r09 = { X86_REG_R9, qword, 0x40U };
-    constexpr struct reg r10 = { X86_REG_R10, qword, 0x48U };
-    constexpr struct reg r11 = { X86_REG_R11, qword, 0x50U };
-    constexpr struct reg r12 = { X86_REG_R12, qword, 0x58U };
-    constexpr struct reg r13 = { X86_REG_R13, qword, 0x60U };
-    constexpr struct reg r14 = { X86_REG_R14, qword, 0x68U };
-    constexpr struct reg r15 = { X86_REG_R15, qword, 0x70U };
+constexpr struct reg r08 = { X86_REG_R8, qword, 0x38U };
+constexpr struct reg r09 = { X86_REG_R9, qword, 0x40U };
+constexpr struct reg r10 = { X86_REG_R10, qword, 0x48U };
+constexpr struct reg r11 = { X86_REG_R11, qword, 0x50U };
+constexpr struct reg r12 = { X86_REG_R12, qword, 0x58U };
+constexpr struct reg r13 = { X86_REG_R13, qword, 0x60U };
+constexpr struct reg r14 = { X86_REG_R14, qword, 0x68U };
+constexpr struct reg r15 = { X86_REG_R15, qword, 0x70U };
 
-    constexpr struct reg ip = { X86_REG_IP, word, 0x78U };
-    constexpr struct reg eip = { X86_REG_EIP, dword, 0x78U };
-    constexpr struct reg rip = { X86_REG_RIP, qword, 0x78U };
+constexpr struct reg ip = { X86_REG_IP, word, 0x78U };
+constexpr struct reg eip = { X86_REG_EIP, dword, 0x78U };
+constexpr struct reg rip = { X86_REG_RIP, qword, 0x78U };
 
-    constexpr struct reg sp = { X86_REG_SP, word, 0x80U };
-    constexpr struct reg esp = { X86_REG_ESP, dword, 0x80U };
-    constexpr struct reg rsp = { X86_REG_RSP, qword, 0x80U };
+constexpr struct reg sp = { X86_REG_SP, word, 0x80U };
+constexpr struct reg esp = { X86_REG_ESP, dword, 0x80U };
+constexpr struct reg rsp = { X86_REG_RSP, qword, 0x80U };
 
-    const std::unordered_map<enum x86_reg, struct reg> reg_map = {
-        {al.id, al},
-        {ah.id, ah},
-        {ax.id, ax},
-        {eax.id, eax},
-        {rax.id, rax},
+const std::unordered_map<enum x86_reg, struct reg> reg_map = {
+    {al.id, al},
+    {ah.id, ah},
+    {ax.id, ax},
+    {eax.id, eax},
+    {rax.id, rax},
 
-        {bl.id, bl},
-        {bh.id, bh},
-        {bx.id, bx},
-        {ebx.id, ebx},
-        {rbx.id, rbx},
+    {bl.id, bl},
+    {bh.id, bh},
+    {bx.id, bx},
+    {ebx.id, ebx},
+    {rbx.id, rbx},
 
-        {cl.id, cl},
-        {ch.id, ch},
-        {cx.id, cx},
-        {ecx.id, ecx},
-        {rcx.id, rcx},
+    {cl.id, cl},
+    {ch.id, ch},
+    {cx.id, cx},
+    {ecx.id, ecx},
+    {rcx.id, rcx},
 
-        {dl.id, dl},
-        {dh.id, dh},
-        {dx.id, dx},
-        {edx.id, edx},
-        {rdx.id, rdx},
+    {dl.id, dl},
+    {dh.id, dh},
+    {dx.id, dx},
+    {edx.id, edx},
+    {rdx.id, rdx},
 
-        {bp.id, bp},
-        {ebp.id, ebp},
-        {rbp.id, rbp},
+    {bp.id, bp},
+    {ebp.id, ebp},
+    {rbp.id, rbp},
 
-        {si.id, si},
-        {esi.id, esi},
-        {rsi.id, rsi},
+    {si.id, si},
+    {esi.id, esi},
+    {rsi.id, rsi},
 
-        {di.id, di},
-        {edi.id, edi},
-        {rdi.id, rdi},
+    {di.id, di},
+    {edi.id, edi},
+    {rdi.id, rdi},
 
-        {r08.id, r08},
-        {r09.id, r09},
-        {r10.id, r10},
-        {r11.id, r11},
-        {r12.id, r12},
-        {r13.id, r13},
-        {r14.id, r14},
-        {r15.id, r15},
+    {r08.id, r08},
+    {r09.id, r09},
+    {r10.id, r10},
+    {r11.id, r11},
+    {r12.id, r12},
+    {r13.id, r13},
+    {r14.id, r14},
+    {r15.id, r15},
 
-        {ip.id, ip},
-        {eip.id, eip},
-        {rip.id, rip},
+    {ip.id, ip},
+    {eip.id, eip},
+    {rip.id, rip},
 
-        {sp.id, sp},
-        {esp.id, esp},
-        {rsp.id, rsp}
-    };
+    {sp.id, sp},
+    {esp.id, esp},
+    {rsp.id, rsp}
+};
 
-    using bfvmm::intel_x64::save_state_t;
+using bfvmm::intel_x64::save_state_t;
 
-    inline uint8_t read8(const save_state_t *state, uint64_t byte_offset)
-    {
-        expects(byte_offset < 0x88U);
-        auto addr = reinterpret_cast<const uintptr_t>(state) + byte_offset;
-        return *reinterpret_cast<const uint8_t *>(addr);
-    }
+inline uint8_t read8(const save_state_t *state, uint64_t byte_offset)
+{
+    expects(byte_offset < 0x88U);
+    auto addr = reinterpret_cast<const uintptr_t>(state) + byte_offset;
+    return *reinterpret_cast<const uint8_t *>(addr);
+}
 
-    inline uint16_t read16(const save_state_t *state, uint64_t byte_offset)
-    {
-        expects(byte_offset <= 0x86U);
-        auto addr = reinterpret_cast<const uintptr_t>(state) + byte_offset;
-        return *reinterpret_cast<const uint16_t *>(addr);
-    }
+inline uint16_t read16(const save_state_t *state, uint64_t byte_offset)
+{
+    expects(byte_offset <= 0x86U);
+    auto addr = reinterpret_cast<const uintptr_t>(state) + byte_offset;
+    return *reinterpret_cast<const uint16_t *>(addr);
+}
 
-    inline uint32_t read32(const save_state_t *state, uint64_t byte_offset)
-    {
-        expects(byte_offset <= 0x84U);
-        auto addr = reinterpret_cast<const uintptr_t>(state) + byte_offset;
-        return *reinterpret_cast<const uint32_t *>(addr);
-    }
+inline uint32_t read32(const save_state_t *state, uint64_t byte_offset)
+{
+    expects(byte_offset <= 0x84U);
+    auto addr = reinterpret_cast<const uintptr_t>(state) + byte_offset;
+    return *reinterpret_cast<const uint32_t *>(addr);
+}
 
-    inline uint64_t read64(const save_state_t *state, uint64_t byte_offset)
-    {
-        expects(byte_offset <= 0x80U);
-        auto addr = reinterpret_cast<const uintptr_t>(state) + byte_offset;
-        return *reinterpret_cast<const uint64_t *>(addr);
-    }
+inline uint64_t read64(const save_state_t *state, uint64_t byte_offset)
+{
+    expects(byte_offset <= 0x80U);
+    auto addr = reinterpret_cast<const uintptr_t>(state) + byte_offset;
+    return *reinterpret_cast<const uint64_t *>(addr);
+}
 
-    /// We return unsigned here because this function is intended
-    /// to be used with unsigned values, like xAPIC regs. The name
-    /// should probably be changed reflect this.
-    inline uint64_t read_imm_val(const save_state_t *state, const cs_x86_op *op)
-    { return static_cast<uint64_t>(op->imm); }
+/// We return unsigned here because this function is intended
+/// to be used with unsigned values, like xAPIC regs. The name
+/// should probably be changed reflect this.
+inline uint64_t read_imm_val(const save_state_t *state, const cs_x86_op *op)
+{ return static_cast<uint64_t>(op->imm); }
 
-    inline uint64_t read_reg_val(const save_state_t *state, const cs_x86_op *op)
-    {
-        const auto reg = reg_map.at(op->reg);
+inline uint64_t read_reg_val(const save_state_t *state, const cs_x86_op *op)
+{
+    const auto reg = reg_map.at(op->reg);
 
-        switch (reg.width) {
-            case qword: return read64(state, reg.byte_offset);
-            case dword: return read32(state, reg.byte_offset);
-            case word: return read16(state, reg.byte_offset);
-            case byte: return read8(state, reg.byte_offset);
+    switch (reg.width) {
+        case qword: return read64(state, reg.byte_offset);
+        case dword: return read32(state, reg.byte_offset);
+        case word: return read16(state, reg.byte_offset);
+        case byte: return read8(state, reg.byte_offset);
 
-            default:
-                throw std::invalid_argument(
+        default:
+            throw std::invalid_argument(
                 "invalid capstone::reg width: " + std::to_string(reg.width));
-        }
     }
+}
 
-    inline uint64_t read_mem_val(const save_state_t *state, const cs_x86_op *op)
-    {
-        bfalert_info(0, "read_mem_value");
-        bfdebug_nhex(0, "op->mem.segment", op->mem.segment);
-        bfdebug_nhex(0, "op->mem.base", op->mem.base);
-        bfdebug_nhex(0, "op->mem.index", op->mem.index);
-        bfdebug_nhex(0, "op->mem.scale", op->mem.scale);
-        bfdebug_nhex(0, "op->mem.disp", op->mem.disp);
+inline uint64_t read_mem_val(const save_state_t *state, const cs_x86_op *op)
+{
+    bfalert_info(0, "read_mem_value");
+    bfdebug_nhex(0, "op->mem.segment", op->mem.segment);
+    bfdebug_nhex(0, "op->mem.base", op->mem.base);
+    bfdebug_nhex(0, "op->mem.index", op->mem.index);
+    bfdebug_nhex(0, "op->mem.scale", op->mem.scale);
+    bfdebug_nhex(0, "op->mem.disp", op->mem.disp);
 
-        throw std::runtime_error("capstone: unexpected mem read");
-     }
+    throw std::runtime_error("capstone: unexpected mem read");
+}
 
-    inline uint64_t read_op_val(
-        const save_state_t *state, const cs_insn *insn, size_t op_index)
-    {
-        expects(op_index < insn->detail->x86.op_count);
+inline uint64_t read_op_val(
+    const save_state_t *state, const cs_insn *insn, size_t op_index)
+{
+    expects(op_index < insn->detail->x86.op_count);
 
-        const auto op = &insn->detail->x86.operands[op_index];
-        const auto type = static_cast<uint64_t>(op->type);
+    const auto op = &insn->detail->x86.operands[op_index];
+    const auto type = static_cast<uint64_t>(op->type);
 
-        switch (type) {
-            case X86_OP_IMM: return read_imm_val(state, op);
-            case X86_OP_REG: return read_reg_val(state, op);
-            case X86_OP_MEM: return read_mem_val(state, op);
+    switch (type) {
+        case X86_OP_IMM: return read_imm_val(state, op);
+        case X86_OP_REG: return read_reg_val(state, op);
+        case X86_OP_MEM: return read_mem_val(state, op);
 
-            default:
-                throw std::runtime_error(
+        default:
+            throw std::runtime_error(
                 "unexpected capstone op.type: " + std::to_string(type));
-        }
     }
+}
 
-    /// @endcond
+/// @endcond
 }
 }
 }

--- a/bfvmm/include/hve/arch/intel_x64/base.h
+++ b/bfvmm/include/hve/arch/intel_x64/base.h
@@ -184,8 +184,7 @@ protected:
     {
         using namespace vmcs_n::exit_qualification::control_register_access;
 
-        switch (general_purpose_register::get())
-        {
+        switch (general_purpose_register::get()) {
             case general_purpose_register::rax:
                 return vmcs->save_state()->rax;
 

--- a/bfvmm/include/hve/arch/intel_x64/cpuid.h
+++ b/bfvmm/include/hve/arch/intel_x64/cpuid.h
@@ -45,9 +45,10 @@ struct pair_hash {
     /// @return the hash of p
     ///
     template <typename T1, typename T2>
-    std::size_t operator () (const std::pair<T1,T2> &p) const {
-        return ((std::hash<T1>{}(p.first) & 0x00000000FFFFFFFF) > 0) |
-               ((std::hash<T2>{}(p.second) & 0xFFFFFFFF00000000) > 32);
+    std::size_t operator()(const std::pair<T1, T2> &p) const
+    {
+        return ((std::hash<T1> {}(p.first) & 0x00000000FFFFFFFF) > 0) |
+               ((std::hash<T2> {}(p.second) & 0xFFFFFFFF00000000) > 32);
     }
 };
 

--- a/bfvmm/include/hve/arch/intel_x64/ept/helpers.h
+++ b/bfvmm/include/hve/arch/intel_x64/ept/helpers.h
@@ -108,7 +108,7 @@ void disable_ept(void);
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
 void map_1g(memory_map &mem_map, gpa_t gpa, hpa_t hpa,
-        memory_attr_t mattr = epte::memory_attr::wb_pt);
+            memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 /// Map n number of contiguous 1GB page frames from the given guest physical
 /// address to given host physical address with the given memory attributes
@@ -123,7 +123,7 @@ void map_1g(memory_map &mem_map, gpa_t gpa, hpa_t hpa,
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
 void map_n_contig_1g(memory_map &mem_map, gpa_t gpa, hpa_t hpa, uint64_t n,
-        memory_attr_t mattr = epte::memory_attr::wb_pt);
+                     memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 /// Map the range of guest physical addresses from gpa_s to gpa_e (inclusive)
 /// to a continuous range of host physical addresses starting at hpa using 1GB
@@ -139,7 +139,7 @@ void map_n_contig_1g(memory_map &mem_map, gpa_t gpa, hpa_t hpa, uint64_t n,
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
 void map_range_1g(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e, hpa_t hpa,
-        memory_attr_t mattr = epte::memory_attr::wb_pt);
+                  memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 /// Identity map 1GB of memory from the guest physical address with the given
 /// memory attributes
@@ -152,7 +152,7 @@ void map_range_1g(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e, hpa_t hpa,
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
 void identity_map_1g(memory_map &mem_map, gpa_t gpa,
-        memory_attr_t mattr = epte::memory_attr::wb_pt);
+                     memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 /// Identity map n number of contiguous 1GB page frames from the given guest
 /// physical address with the given memory attributes
@@ -166,7 +166,7 @@ void identity_map_1g(memory_map &mem_map, gpa_t gpa,
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
 void identity_map_n_contig_1g(memory_map &mem_map, gpa_t gpa, uint64_t n,
-        memory_attr_t mattr = epte::memory_attr::wb_pt);
+                              memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 /// Identity map the range of guest physical addresses from gpa_s to gpa_e
 /// (inclusive) using 1GB page frames and the given memory attributes
@@ -180,7 +180,7 @@ void identity_map_n_contig_1g(memory_map &mem_map, gpa_t gpa, uint64_t n,
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
 void identity_map_range_1g(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e,
-        memory_attr_t mattr = epte::memory_attr::wb_pt);
+                           memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 //--------------------------------------------------------------------------
 // 2MB pages
@@ -198,7 +198,7 @@ void identity_map_range_1g(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e,
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
 void map_2m(memory_map &mem_map, gpa_t gpa, hpa_t hpa,
-        memory_attr_t mattr = epte::memory_attr::wb_pt);
+            memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 /// Map n number of contiguous 2MB page frames from the given guest physical
 /// address to given host physical address with the given memory attributes
@@ -213,7 +213,7 @@ void map_2m(memory_map &mem_map, gpa_t gpa, hpa_t hpa,
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
 void map_n_contig_2m(memory_map &mem_map, gpa_t gpa, hpa_t hpa, uint64_t n,
-        memory_attr_t mattr = epte::memory_attr::wb_pt);
+                     memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 /// Map the range of guest physical addresses from gpa_s to gpa_e (inclusive)
 /// to a continuous range of host physical addresses starting at hpa using 2MB
@@ -229,7 +229,7 @@ void map_n_contig_2m(memory_map &mem_map, gpa_t gpa, hpa_t hpa, uint64_t n,
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
 void map_range_2m(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e, hpa_t hpa,
-        memory_attr_t mattr = epte::memory_attr::wb_pt);
+                  memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 /// Identity map 2MB of memory from the guest physical address with the given
 /// memory attributes
@@ -242,7 +242,7 @@ void map_range_2m(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e, hpa_t hpa,
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
 void identity_map_2m(memory_map &mem_map, gpa_t gpa,
-        memory_attr_t mattr = epte::memory_attr::wb_pt);
+                     memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 /// Identity map n number of contiguous 2MB page frames from the given guest
 /// physical address with the given memory attributes
@@ -256,7 +256,7 @@ void identity_map_2m(memory_map &mem_map, gpa_t gpa,
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
 void identity_map_n_contig_2m(memory_map &mem_map, gpa_t gpa, uint64_t n,
-        memory_attr_t mattr = epte::memory_attr::wb_pt);
+                              memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 /// Identity map the range of guest physical addresses from gpa_s to gpa_e
 /// (inclusive) using 2MB page frames and the given memory attributes
@@ -270,7 +270,7 @@ void identity_map_n_contig_2m(memory_map &mem_map, gpa_t gpa, uint64_t n,
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
 void identity_map_range_2m(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e,
-        memory_attr_t mattr = epte::memory_attr::wb_pt);
+                           memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 //--------------------------------------------------------------------------
 // 4KB pages
@@ -288,7 +288,7 @@ void identity_map_range_2m(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e,
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
 void map_4k(memory_map &mem_map, gpa_t gpa, hpa_t hpa,
-        memory_attr_t mattr = epte::memory_attr::wb_pt);
+            memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 /// Map n number of contiguous 4KB page frames from the given guest physical
 /// address to given host physical address with the given memory attributes
@@ -303,7 +303,7 @@ void map_4k(memory_map &mem_map, gpa_t gpa, hpa_t hpa,
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
 void map_n_contig_4k(memory_map &mem_map, gpa_t gpa, hpa_t hpa, uint64_t n,
-        memory_attr_t mattr = epte::memory_attr::wb_pt);
+                     memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 /// Map the range of guest physical addresses from gpa_s to gpa_e (inclusive)
 /// to a continuous range of host physical addresses starting at hpa using 4KB
@@ -319,7 +319,7 @@ void map_n_contig_4k(memory_map &mem_map, gpa_t gpa, hpa_t hpa, uint64_t n,
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
 void map_range_4k(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e, hpa_t hpa,
-        memory_attr_t mattr = epte::memory_attr::wb_pt);
+                  memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 /// Identity map 4KB of memory from the guest physical address with the given
 /// memory attributes
@@ -332,7 +332,7 @@ void map_range_4k(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e, hpa_t hpa,
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
 void identity_map_4k(memory_map &mem_map, gpa_t gpa,
-        memory_attr_t mattr = epte::memory_attr::wb_pt);
+                     memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 /// Identity map n number of contiguous 4KB page frames from the given guest
 /// physical address with the given memory attributes
@@ -346,7 +346,7 @@ void identity_map_4k(memory_map &mem_map, gpa_t gpa,
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
 void identity_map_n_contig_4k(memory_map &mem_map, gpa_t gpa, uint64_t n,
-        memory_attr_t mattr = epte::memory_attr::wb_pt);
+                              memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 /// Identity map the range of guest physical addresses from gpa_s to gpa_e
 /// (inclusive) using 4KB page frames and the given memory attributes
@@ -360,7 +360,7 @@ void identity_map_n_contig_4k(memory_map &mem_map, gpa_t gpa, uint64_t n,
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
 void identity_map_range_4k(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e,
-        memory_attr_t mattr = epte::memory_attr::wb_pt);
+                           memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 /// Identity map the range of guest physical addresses from gpa_s to gpa_e
 /// (inclusive) using as few pages as possible. This means that 1G pages
@@ -378,7 +378,7 @@ void identity_map_range_4k(memory_map &mem_map, gpa_t gpa_s, gpa_t gpa_e,
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
 void identity_map_bestfit_lo(ept::memory_map &mem_map, gpa_t gpa_s,
-        gpa_t gpa_e, memory_attr_t mattr = epte::memory_attr::wb_pt);
+                             gpa_t gpa_e, memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 /// Identity map the range of guest physical addresses from gpa_s to gpa_e
 /// (inclusive) using as few pages as possible. This means that 4K pages
@@ -395,7 +395,7 @@ void identity_map_bestfit_lo(ept::memory_map &mem_map, gpa_t gpa_s,
 /// @param mattr page table entry memory attributes to be applied to the mapping
 ///
 void identity_map_bestfit_hi(ept::memory_map &mem_map, gpa_t gpa_s,
-        gpa_t gpa_e, memory_attr_t mattr = epte::memory_attr::wb_pt);
+                             gpa_t gpa_e, memory_attr_t mattr = epte::memory_attr::wb_pt);
 
 //--------------------------------------------------------------------------
 // Unmapping

--- a/bfvmm/include/hve/arch/intel_x64/hve.h
+++ b/bfvmm/include/hve/arch/intel_x64/hve.h
@@ -462,7 +462,7 @@ public:
     /// @param d the delegate to call when an exit occurs
     ///
     void add_ept_misconfiguration_handler(
-            ept_misconfiguration::handler_delegate_t &&d);
+        ept_misconfiguration::handler_delegate_t &&d);
 
     //--------------------------------------------------------------------------
     // EPT Violation
@@ -486,7 +486,7 @@ public:
     /// @param d the delegate to call when an exit occurs
     ///
     void add_ept_read_violation_handler(
-            ept_violation::handler_delegate_t &&d);
+        ept_violation::handler_delegate_t &&d);
 
     /// Add EPT write violation handler
     ///
@@ -496,7 +496,7 @@ public:
     /// @param d the delegate to call when an exit occurs
     ///
     void add_ept_write_violation_handler(
-            ept_violation::handler_delegate_t &&d);
+        ept_violation::handler_delegate_t &&d);
 
     /// Add EPT execute violation handler
     ///
@@ -506,7 +506,7 @@ public:
     /// @param d the delegate to call when an exit occurs
     ///
     void add_ept_execute_violation_handler(
-            ept_violation::handler_delegate_t &&d);
+        ept_violation::handler_delegate_t &&d);
 
 
 private:

--- a/bfvmm/include/hve/arch/intel_x64/mtrr.h
+++ b/bfvmm/include/hve/arch/intel_x64/mtrr.h
@@ -45,8 +45,7 @@ static constexpr uint64_t fixed_size = 0x100000U; // First 1MB
 /// Users don't need to care whether the range described by an
 /// instance of this is fixed, variable, or a combination of both
 ///
-struct range
-{
+struct range {
     /// base the base address of the range
     uintptr_t base;
 
@@ -141,8 +140,7 @@ constexpr inline uint64_t mask_to_size(uint64_t mask, uint64_t pas)
 /// Variable MTRR range
 ///
 ///
-struct variable_range
-{
+struct variable_range {
     /// Constructor
     ///
     /// Create a variable range from the physbase and physmask

--- a/bfvmm/include/hve/arch/intel_x64/vic.h
+++ b/bfvmm/include/hve/arch/intel_x64/vic.h
@@ -39,7 +39,7 @@
 
 namespace test
 {
-    class vcpu;
+class vcpu;
 }
 
 namespace eapis
@@ -49,7 +49,7 @@ namespace intel_x64
 
 namespace ept
 {
-    class memory_map;
+class memory_map;
 }
 
 ///-----------------------------------------------------------------------------
@@ -64,10 +64,10 @@ namespace proc_ctl2 = vmcs_n::secondary_processor_based_vm_execution_controls;
 /// Helpers
 ///-----------------------------------------------------------------------------
 
-template<
+template <
     typename N,
-    typename = std::enable_if_t<std::is_integral<N>::value ||
-                                std::is_pointer<N>::value>>
+    typename = std::enable_if_t < std::is_integral<N>::value ||
+                                  std::is_pointer<N>::value >>
 inline void
 throw_vic_fatal(const char *msg, N nhex)
 {

--- a/bfvmm/include/hve/pci_register.h
+++ b/bfvmm/include/hve/pci_register.h
@@ -39,8 +39,7 @@ using func_type = uint8_t;
 using register_type = uint8_t;
 
 /// Full geographical address of a device
-struct device_id
-{
+struct device_id {
     /// Bus number
     bus_type bus;
 

--- a/bfvmm/include/hve/phys_pci.h
+++ b/bfvmm/include/hve/phys_pci.h
@@ -200,7 +200,8 @@ public:
     {
         if (n < 6) {
             return read_register_u32(0x10 + 4 * n);
-        } else {
+        }
+        else {
             return 0xFFFFFFFF;
         }
     }
@@ -390,7 +391,7 @@ public:
     ///         check type().
     bar(phys_pci device, unsigned int index)
         : m_device(device),
-            m_index(index)
+          m_index(index)
     {
         m_type = compute_type();
     }

--- a/bfvmm/include/support/arch/intel_x64/test_support.h
+++ b/bfvmm/include/support/arch/intel_x64/test_support.h
@@ -42,15 +42,13 @@ namespace intel_x64
 {
 namespace lapic
 {
-    std::array<attr_t, count> attributes;
+std::array<attr_t, count> attributes;
 }
 }
 
 ::intel_x64::vmcs::value_type g_vcpuid{0U};
 
 std::unique_ptr<uint32_t[]> g_vmcs_region;
-std::unique_ptr<bfvmm::intel_x64::vmcs> g_vmcs;
-std::unique_ptr<bfvmm::intel_x64::exit_handler> g_ehlr;
 std::unique_ptr<eapis::intel_x64::ept::memory_map> g_emap;
 
 struct platform_info_t g_platform_info;
@@ -88,10 +86,11 @@ extern "C" void _sfence()
 inline auto
 setup_hve()
 {
+    bfignored(g_mm);
     setup_test_support();
 
-    g_vmcs = std::make_unique<bfvmm::intel_x64::vmcs>(g_vcpuid);
-    g_ehlr = std::make_unique<bfvmm::intel_x64::exit_handler>(g_vmcs.get());
+    static auto g_vmcs = std::make_unique<bfvmm::intel_x64::vmcs>(g_vcpuid);
+    static auto g_ehlr = std::make_unique<bfvmm::intel_x64::exit_handler>(g_vmcs.get());
 
     return std::make_unique<eapis::intel_x64::hve>(g_ehlr.get(), g_vmcs.get());
 }

--- a/bfvmm/src/hve/arch/intel_x64/io_instruction.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/io_instruction.cpp
@@ -311,10 +311,10 @@ io_instruction::load_operand(
             case io_instruction::size_of_access::one_byte: {
                 auto map =
                     bfvmm::x64::make_unique_map<uint8_t>(
-                               info.address,
-                               vmcs_n::guest_cr3::get(),
-                               info.size_of_access
-                           );
+                        info.address,
+                        vmcs_n::guest_cr3::get(),
+                        info.size_of_access
+                    );
 
                 info.val = map.get()[0] & 0x00000000000000FFULL;
                 break;
@@ -323,10 +323,10 @@ io_instruction::load_operand(
             case io_instruction::size_of_access::two_byte: {
                 auto map =
                     bfvmm::x64::make_unique_map<uint16_t>(
-                               info.address,
-                               vmcs_n::guest_cr3::get(),
-                               info.size_of_access
-                           );
+                        info.address,
+                        vmcs_n::guest_cr3::get(),
+                        info.size_of_access
+                    );
 
                 info.val = map.get()[0] & 0x000000000000FFFFULL;
                 break;
@@ -335,10 +335,10 @@ io_instruction::load_operand(
             default: {
                 auto map =
                     bfvmm::x64::make_unique_map<uint32_t>(
-                               info.address,
-                               vmcs_n::guest_cr3::get(),
-                               info.size_of_access
-                           );
+                        info.address,
+                        vmcs_n::guest_cr3::get(),
+                        info.size_of_access
+                    );
 
                 info.val = map.get()[0] & 0x00000000FFFFFFFFULL;
                 break;
@@ -373,10 +373,10 @@ io_instruction::store_operand(
             case io_instruction::size_of_access::one_byte: {
                 auto map =
                     bfvmm::x64::make_unique_map<uint8_t>(
-                               info.address,
-                               vmcs_n::guest_cr3::get(),
-                               info.size_of_access
-                           );
+                        info.address,
+                        vmcs_n::guest_cr3::get(),
+                        info.size_of_access
+                    );
 
                 map.get()[0] = gsl::narrow_cast<uint8_t>(info.val);
                 break;
@@ -385,10 +385,10 @@ io_instruction::store_operand(
             case io_instruction::size_of_access::two_byte: {
                 auto map =
                     bfvmm::x64::make_unique_map<uint16_t>(
-                               info.address,
-                               vmcs_n::guest_cr3::get(),
-                               info.size_of_access
-                           );
+                        info.address,
+                        vmcs_n::guest_cr3::get(),
+                        info.size_of_access
+                    );
 
                 map.get()[0] = gsl::narrow_cast<uint16_t>(info.val);
                 break;
@@ -397,10 +397,10 @@ io_instruction::store_operand(
             default: {
                 auto map =
                     bfvmm::x64::make_unique_map<uint32_t>(
-                               info.address,
-                               vmcs_n::guest_cr3::get(),
-                               info.size_of_access
-                           );
+                        info.address,
+                        vmcs_n::guest_cr3::get(),
+                        info.size_of_access
+                    );
 
                 map.get()[0] = gsl::narrow_cast<uint32_t>(info.val);
                 break;

--- a/bfvmm/tests/hve/arch/intel_x64/ept/test_helpers.cpp
+++ b/bfvmm/tests/hve/arch/intel_x64/ept/test_helpers.cpp
@@ -34,6 +34,9 @@ namespace test_ept
 
 TEST_CASE("ept::align_1g")
 {
+    int i[10];
+    i[0] = 0;
+
     auto addr = 0x1122334455667788U;
     CHECK(ept::align_1g(addr) == (addr & ~(ept::page_size_1g - 1U)));
 }

--- a/bfvmm/tests/hve/arch/intel_x64/test_vic.cpp
+++ b/bfvmm/tests/hve/arch/intel_x64/test_vic.cpp
@@ -619,7 +619,7 @@ TEST_CASE("vic: disasm_xapic_write cs_open error")
     cs_insn *insn;
     const uint8_t rip[1] = { 0xC3U };
 
-//     mocks.OnCallFunc(cs_open).Return(static_cast<cs_err>(CS_ERR_OK + 1U));
+    //     mocks.OnCallFunc(cs_open).Return(static_cast<cs_err>(CS_ERR_OK + 1U));
     CHECK_THROWS(disasm_xapic_write(&cs, &insn, rip));
 }
 
@@ -629,7 +629,7 @@ TEST_CASE("vic: disasm_xapic_write nr_disasm != need")
     cs_insn *insn;
     const uint8_t rip[1] = { 0xC3U };
 
-//     mocks.OnCallFunc(cs_disasm).Return(0U);
+    //     mocks.OnCallFunc(cs_disasm).Return(0U);
     CHECK_THROWS(disasm_xapic_write(&cs, &insn, rip));
 }
 


### PR DESCRIPTION
The EAPIs unit tests fail when ASAN is enabled as there is a memory
leak during destruction. This patch fixes this by removing the
global versions of the exit handler and VMCS which are causing a
construction race with the memory manager.

Signed-off-by: Rian Quinn <rianquinn@gmail.com>